### PR TITLE
Building the juce plugin can be optionally turned off.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ project(virusEmu VERSION 1.1.5)
 include(base.cmake)
 
 set(ASMJIT_STATIC TRUE)
-
+option(${PROJECT_NAME}_BUILD_JUCEPLUGIN "Build Juce plugin" on)
 add_subdirectory(source/dsp56300/source)
 add_subdirectory(source/synthLib)
 add_subdirectory(source/virusLib)
@@ -25,14 +25,17 @@ add_subdirectory(source/ctrlr/JUCE)
 
 # ----------------- Juce based audio plugin
 
+
 set_property(GLOBAL PROPERTY USE_FOLDERS YES)
-set(JUCE_ENABLE_MODULE_SOURCE_GROUPS ON CACHE BOOL "" FORCE)
+if(${PROJECT_NAME}_BUILD_JUCEPLUGIN)
+	set(JUCE_ENABLE_MODULE_SOURCE_GROUPS ON CACHE BOOL "" FORCE)
+	add_subdirectory(source/jucePlugin)
+	if(UNIX AND NOT APPLE)
+		install(TARGETS jucePlugin_VST LIBRARY DESTINATION /usr/local/lib/lxvst/ COMPONENT plugin)
+	endif()
 
-add_subdirectory(source/jucePlugin)
-
-if(UNIX AND NOT APPLE)
-	install(TARGETS jucePlugin_VST LIBRARY DESTINATION /usr/local/lib/lxvst/ COMPONENT plugin)
 endif()
+
 
 # ----------------- Test Console
 


### PR DESCRIPTION
In order to run cmake config, juce_set_vst2_sdk_path needs to be set. If you just want to build the test console program without generating a vst, you are out of luck without modifying the cmakelists.txt. if cmake is called with "-DvirusEmu_BUILD_JUCEPLUGIN=false" the rest of the project can be configured and built.

Also, I see the project is still titled, "virusEmu".  I'll create a new pr for to renaming it to gearemulator, which will make this option flag gearemulator_BUILD_JUCEPLUGIN