### PR TITLE
add github actions for building with GCC, Apple Clang, and MSVC

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,29 @@
+name: CMake
+
+on: [push, pull_request]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+      fail-fast: false
+    name:  ${{ matrix.os }} build
+    steps:
+    - name: Install X
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt update && sudo apt install -y libgl1-mesa-dev xorg-dev
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: "recursive"
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -Dgearmulator_BUILD_JUCEPLUGIN:BOOL=FALSE
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}


### PR DESCRIPTION
This currently builds with -Dgearmulator_BUILD_JUCEPLUGIN:BOOL=FALSE.  juce_set_vst2_sdk_path issue is resolved, this line can be taken out