### PR TITLE
Fix some sysex issues.

### DIFF
--- a/source/virusLib/microcontroller.h
+++ b/source/virusLib/microcontroller.h
@@ -174,6 +174,8 @@ public:
 		PlayModeMulti,
 	};
 
+	const uint8_t OMNI_DEVICE_ID = 0x10;
+
 	using TPreset = ROMFile::TPreset;
 
 	explicit Microcontroller(dsp56k::HDI08& hdi08, ROMFile& romFile);


### PR DESCRIPTION
Allow omni device id. Apply changes to correct edit buffer. Act like a virus when changing params in single mode.