### PR TITLE
Fix bank loading order

### DIFF
--- a/source/virusLib/microcontroller.cpp
+++ b/source/virusLib/microcontroller.cpp
@@ -53,10 +53,10 @@ Microcontroller::Microcontroller(HDI08& _hdi08, ROMFile& _romFile) : m_hdi08(_hd
 	{
 		std::vector<TPreset> singles;
 
+		const auto bank = b >= g_singleRamBankCount ? b - g_singleRamBankCount : b;
+
 		for(uint32_t p=0; p<g_presetsPerBank; ++p)
 		{
-			const auto bank = b > g_singleRamBankCount ? b - g_singleRamBankCount : b;
-
 			TPreset single;
 			m_rom.getSingle(bank, p, single);
 


### PR DESCRIPTION
Right now it loads as A,B,C,B,C,D,E,F and Bank C in the popup shows the third read-only bank instead of the first one.
Should be A,B,A,B,C,D,E,F, I think?