### PR TITLE
add prev/next preset select buttons. expose device id parameter

### DIFF
--- a/source/jucePlugin/PluginEditor.cpp
+++ b/source/jucePlugin/PluginEditor.cpp
@@ -68,7 +68,26 @@ AudioPluginAudioProcessorEditor::AudioPluginAudioProcessorEditor(AudioPluginAudi
 			}
 			selector.showMenu(juce::PopupMenu::Options());
 		};
+		m_partSelectors[pt].setSize(m_partSelectors[pt].getWidth() - 48, m_partSelectors[pt].getHeight());
+		m_partSelectors[pt].setTopLeftPosition(m_partSelectors[pt].getPosition() + juce::Point(24, 0));
 		addAndMakeVisible(m_partSelectors[pt]);
+
+		m_prevPatch[pt].setSize(24, m_partSelectors[pt].getHeight());
+		m_nextPatch[pt].setSize(24, m_partSelectors[pt].getHeight());
+		m_prevPatch[pt].setTopLeftPosition(m_partSelectors[pt].getPosition() - juce::Point(24, 0));
+		m_nextPatch[pt].setTopLeftPosition(m_partSelectors[pt].getPosition() + juce::Point(m_partSelectors[pt].getWidth(), 0));
+		m_prevPatch[pt].setButtonText("<");
+		m_nextPatch[pt].setButtonText(">");
+		m_prevPatch[pt].onClick = [this, pt]() {
+			processorRef.getController().setCurrentPartPreset(pt, processorRef.getController().getCurrentPartBank(pt),
+															  std::max(0, processorRef.getController().getCurrentPartProgram(pt) - 1));
+		};
+		m_nextPatch[pt].onClick = [this, pt]() {
+			processorRef.getController().setCurrentPartPreset(pt, processorRef.getController().getCurrentPartBank(pt),
+															  std::min(127, processorRef.getController().getCurrentPartProgram(pt) + 1));
+		};
+		addAndMakeVisible(m_prevPatch[pt]);
+		addAndMakeVisible(m_nextPatch[pt]);
 	}
 	
 	auto midiIn = m_properties->getValue("midi_input", "");
@@ -218,6 +237,8 @@ void AudioPluginAudioProcessorEditor::timerCallback()
 	{
 		bool singlePartOrInMulti = pt == 0 || multiMode;
 		m_partSelectors[pt].setVisible(singlePartOrInMulti);
+		m_prevPatch[pt].setVisible(singlePartOrInMulti);
+		m_nextPatch[pt].setVisible(singlePartOrInMulti);
 		if (singlePartOrInMulti)
 			m_partSelectors[pt].setButtonText(processorRef.getController().getCurrentPartPresetName(pt));
 	}

--- a/source/jucePlugin/PluginEditor.h
+++ b/source/jucePlugin/PluginEditor.h
@@ -26,13 +26,15 @@ private:
 
 	juce::GenericAudioProcessorEditor m_tempEditor;
 	juce::TextButton m_partSelectors[16];
-
+	juce::TextButton m_prevPatch[16];
+	juce::TextButton m_nextPatch[16];
 	juce::TextButton m_btSingleMode;
 	juce::TextButton m_btMultiMode;
 	juce::TextButton m_btLoadFile;
 	juce::String m_previousPath;
 	juce::ComboBox m_cmbMidiInput;
 	juce::ComboBox m_cmbMidiOutput;
+
 	juce::AudioDeviceManager deviceManager;
 	juce::PropertiesFile *m_properties;
 	int m_lastInputIndex = 0;

--- a/source/jucePlugin/VirusController.cpp
+++ b/source/jucePlugin/VirusController.cpp
@@ -228,8 +228,12 @@ namespace Virus
 			patch.push_back(preset.data[i]);
 		sendSysEx(constructMessage(patch));
 		sendSysEx(constructMessage({MessageType::REQUEST_ARRANGEMENT}));
+		m_currentBank[part] = bank;
+		m_currentProgram[part] = prg;
 	}
 
+	uint8_t Controller::getCurrentPartBank(uint8_t part) { return m_currentBank[part]; }
+	uint8_t Controller::getCurrentPartProgram(uint8_t part) { return m_currentProgram[part]; }
 	void Controller::parseSingle(const SysEx &msg)
 	{
         constexpr auto pageSize = 128;
@@ -1488,7 +1492,7 @@ namespace Virus
     {Parameter::Page::C, Parameter::Class::GLOBAL, 90, "Input Thru Level", {0,127}, {},{}, false, false, false},
     {Parameter::Page::C, Parameter::Class::GLOBAL, 91, "Input Boost", {0,127}, {},{}, false, false, false},
     {Parameter::Page::C, Parameter::Class::GLOBAL, 92, "Master Tune", {0,127}, paramTo7bitSigned, textTo7bitSigned, false, false, false},
-    {Parameter::Page::C, Parameter::Class::GLOBAL, 93, "Device ID", {0,16}, {},{}, false, true, false},
+    {Parameter::Page::C, Parameter::Class::GLOBAL, 93, "Device ID", {0,16}, {},{}, true, true, false},
     {Parameter::Page::C, Parameter::Class::GLOBAL, 94, "Midi Control Low Page", {0,1}, {},{}, false, false, true},
     {Parameter::Page::C, Parameter::Class::GLOBAL, 95, "Midi Control High Page", {0,1}, {},{}, false, false, true},
     {Parameter::Page::C, Parameter::Class::GLOBAL, 96, "Midi Arpeggiator Send", {0,1}, {},{}, false, false, true},

--- a/source/jucePlugin/VirusController.cpp
+++ b/source/jucePlugin/VirusController.cpp
@@ -1514,7 +1514,7 @@ namespace Virus
     {Parameter::Page::C, Parameter::Class::GLOBAL, 121, "Panel Destination", {0,2}, {},{}, false, true, false},
     {Parameter::Page::C, Parameter::Class::GLOBAL, 122, "Play Mode", {0,2}, {},{}, false, true, false},
     {Parameter::Page::C, Parameter::Class::GLOBAL, 123, "Part Number", {0,127}, {},{}, false, true, false}, // 0..15;40
-    {Parameter::Page::C, Parameter::Class::GLOBAL, 124, "Global Channel", {0,15}, {},{}, false, true, false},
+    {Parameter::Page::C, Parameter::Class::GLOBAL, 124, "Global Channel", {0,15}, {},{}, true, true, false},
     {Parameter::Page::C, Parameter::Class::GLOBAL, 125, "Led Mode", {0,2}, {},{}, false, true, false},
     {Parameter::Page::C, Parameter::Class::GLOBAL, 126, "LCD Contrast", {0,127}, {},{}, false, false, false},
     {Parameter::Page::C, Parameter::Class::GLOBAL, 127, "Master Volume", {0,127}, {},{}, false, false, false},

--- a/source/jucePlugin/VirusController.h
+++ b/source/jucePlugin/VirusController.h
@@ -34,13 +34,14 @@ namespace Virus
 		bool isMultiMode() { return getParam(0, 2, 0x7a)->getValue(); }
 		// part 0 - 15 (ignored when single! 0x40...)
 		void setCurrentPartPreset(uint8_t part, uint8_t bank, uint8_t prg);
+		uint8_t getCurrentPartBank(uint8_t part);
+		uint8_t getCurrentPartProgram(uint8_t part);
 		juce::String getCurrentPartPresetName(uint8_t part);
 		uint32_t getBankCount() const { return static_cast<uint32_t>(m_singles.size()); }
 		void parseMessage(const SysEx &);
 		void sendSysEx(const SysEx &);
 	private:
 		void timerCallback() override;
-
         static constexpr size_t kDataSizeInBytes = 256; // same for multi and single
 
         struct MultiPatch
@@ -102,5 +103,7 @@ namespace Virus
         juce::CriticalSection m_eventQueueLock;
         std::vector<synthLib::SMidiEvent> m_virusOut;
         unsigned char m_deviceId;
+        uint8_t m_currentBank[16];
+        uint8_t m_currentProgram[16];
     };
 }; // namespace Virus


### PR DESCRIPTION
couldn't find an existing variable that tracked current bank/program per part and the data in the multi didn't seem to be correct so added some new variables to track it's when changed. if there's a better existing place to get that data let me know and i'll update this.