### PR TITLE
Use async api instead of synchornized for popup/browser dialog;tidy namespace

### DIFF
--- a/source/jucePlugin/ui/VirusEditor.cpp
+++ b/source/jucePlugin/ui/VirusEditor.cpp
@@ -83,7 +83,7 @@ VirusEditor::VirusEditor(VirusParameterBinding &_parameterBinding, AudioPluginAu
     index = 0;
     m_mainButtons.applyToMainButtons([this, &index](DrawableButton *s) mutable {
         if (currentTab == index) {
-            s->setToggleState(true, juce::dontSendNotification);
+            s->setToggleState(true, dontSendNotification);
         }
         index++;
     });
@@ -112,8 +112,8 @@ VirusEditor::VirusEditor(VirusParameterBinding &_parameterBinding, AudioPluginAu
     addAndMakeVisible(m_cmbMidiInput);
     addAndMakeVisible(m_cmbMidiOutput);
     m_cmbMidiInput.setTextWhenNoChoicesAvailable("No MIDI Inputs Enabled");
-    auto midiInputs = juce::MidiInput::getAvailableDevices();
-    juce::StringArray midiInputNames;
+    auto midiInputs = MidiInput::getAvailableDevices();
+    StringArray midiInputNames;
     midiInputNames.add(" - Midi In - ");
     auto inIndex = 0;
     for (int i = 0; i < midiInputs.size(); i++)
@@ -126,10 +126,10 @@ VirusEditor::VirusEditor(VirusParameterBinding &_parameterBinding, AudioPluginAu
         midiInputNames.add(input.name);
     }
     m_cmbMidiInput.addItemList(midiInputNames, 1);
-    m_cmbMidiInput.setSelectedItemIndex(inIndex, juce::dontSendNotification);
+    m_cmbMidiInput.setSelectedItemIndex(inIndex, dontSendNotification);
     m_cmbMidiOutput.setTextWhenNoChoicesAvailable("No MIDI Outputs Enabled");
-    auto midiOutputs = juce::MidiOutput::getAvailableDevices();
-    juce::StringArray midiOutputNames;
+    auto midiOutputs = MidiOutput::getAvailableDevices();
+    StringArray midiOutputNames;
     midiOutputNames.add(" - Midi Out - ");
     auto outIndex = 0;
     for (int i = 0; i < midiOutputs.size(); i++)
@@ -143,7 +143,7 @@ VirusEditor::VirusEditor(VirusParameterBinding &_parameterBinding, AudioPluginAu
         midiOutputNames.add(output.name);
     }
     m_cmbMidiOutput.addItemList(midiOutputNames, 1);
-    m_cmbMidiOutput.setSelectedItemIndex(outIndex, juce::dontSendNotification);
+    m_cmbMidiOutput.setSelectedItemIndex(outIndex, dontSendNotification);
     m_cmbMidiInput.onChange = [this]() { updateMidiInput(m_cmbMidiInput.getSelectedItemIndex()); };
     m_cmbMidiOutput.onChange = [this]() { updateMidiOutput(m_cmbMidiOutput.getSelectedItemIndex()); };
 
@@ -156,14 +156,14 @@ VirusEditor::VirusEditor(VirusParameterBinding &_parameterBinding, AudioPluginAu
     message += "\n\nROM Loaded: " + _processorRef.getRomName();
     m_version.setText(message, NotificationType::dontSendNotification);
     m_version.setBounds(94, 2, 220, 150);
-    m_version.setColour(juce::Label::textColourId, juce::Colours::white);
+    m_version.setColour(Label::textColourId, Colours::white);
     m_version.setJustificationType(Justification::centred);
     addAndMakeVisible(m_version);
 
     m_patchName.setBounds(410, 48, 362, 36);
     m_patchName.setJustificationType(Justification::left);
-    m_patchName.setFont(juce::Font(32.0f, juce::Font::bold));
-    m_patchName.setColour(juce::Label::textColourId, juce::Colour(255, 113, 128));
+    m_patchName.setFont(Font(32.0f, Font::bold));
+    m_patchName.setColour(Label::textColourId, Colour(255, 113, 128));
     m_patchName.setEditable(false, true, true);
     m_patchName.onTextChange = [this]() {
         auto text = m_patchName.getText();
@@ -177,10 +177,10 @@ VirusEditor::VirusEditor(VirusParameterBinding &_parameterBinding, AudioPluginAu
     m_controlLabel.setBounds(m_patchName.getBounds().translated(m_controlLabel.getWidth(), 0));
     m_controlLabel.setSize(m_patchName.getWidth()/2, m_patchName.getHeight());
     m_controlLabel.setJustificationType(Justification::topRight);
-    m_controlLabel.setColour(juce::Label::textColourId, juce::Colour(255, 113, 128));
-    m_controlLabel.setFont(juce::Font(16.0f, juce::Font::bold));
-    //m_controlLabel.setColour(juce::Label::ColourIds::backgroundColourId, juce::Colours::black);
-    //m_controlLabel.setColour(juce::Label::ColourIds::outlineColourId, juce::Colours::white);
+    m_controlLabel.setColour(Label::textColourId, Colour(255, 113, 128));
+    m_controlLabel.setFont(Font(16.0f, Font::bold));
+    //m_controlLabel.setColour(Label::ColourIds::backgroundColourId, Colours::black);
+    //m_controlLabel.setColour(Label::ColourIds::outlineColourId, Colours::white);
 
     addAndMakeVisible(m_controlLabel);
 
@@ -220,14 +220,14 @@ void VirusEditor::updateParts() {
 
 void VirusEditor::updateMidiInput(int index)
 {
-    auto list = juce::MidiInput::getAvailableDevices();
+    auto list = MidiInput::getAvailableDevices();
 
     if (index == 0)
     {
         m_properties->setValue("midi_input", "");
         m_properties->save();
         m_lastInputIndex = index;
-        m_cmbMidiInput.setSelectedItemIndex(index, juce::dontSendNotification);
+        m_cmbMidiInput.setSelectedItemIndex(index, dontSendNotification);
         return;
     }
     index--;
@@ -238,7 +238,7 @@ void VirusEditor::updateMidiInput(int index)
 
     if (!processorRef.setMidiInput(newInput.identifier))
     {
-        m_cmbMidiInput.setSelectedItemIndex(0, juce::dontSendNotification);
+        m_cmbMidiInput.setSelectedItemIndex(0, dontSendNotification);
         m_lastInputIndex = 0;
         return;
     }
@@ -246,18 +246,18 @@ void VirusEditor::updateMidiInput(int index)
     m_properties->setValue("midi_input", newInput.identifier);
     m_properties->save();
 
-    m_cmbMidiInput.setSelectedItemIndex(index + 1, juce::dontSendNotification);
+    m_cmbMidiInput.setSelectedItemIndex(index + 1, dontSendNotification);
     m_lastInputIndex = index;
 }
 void VirusEditor::updateMidiOutput(int index)
 {
-    auto list = juce::MidiOutput::getAvailableDevices();
+    auto list = MidiOutput::getAvailableDevices();
 
     if (index == 0)
     {
         m_properties->setValue("midi_output", "");
         m_properties->save();
-        m_cmbMidiOutput.setSelectedItemIndex(index, juce::dontSendNotification);
+        m_cmbMidiOutput.setSelectedItemIndex(index, dontSendNotification);
         m_lastOutputIndex = index;
         processorRef.setMidiOutput("");
         return;
@@ -266,14 +266,14 @@ void VirusEditor::updateMidiOutput(int index)
     auto newOutput = list[index];
     if (!processorRef.setMidiOutput(newOutput.identifier))
     {
-        m_cmbMidiOutput.setSelectedItemIndex(0, juce::dontSendNotification);
+        m_cmbMidiOutput.setSelectedItemIndex(0, dontSendNotification);
         m_lastOutputIndex = 0;
         return;
     }
     m_properties->setValue("midi_output", newOutput.identifier);
     m_properties->save();
 
-    m_cmbMidiOutput.setSelectedItemIndex(index + 1, juce::dontSendNotification);
+    m_cmbMidiOutput.setSelectedItemIndex(index + 1, dontSendNotification);
     m_lastOutputIndex = index;
 }
 void VirusEditor::applyToSections(std::function<void(Component *)> action)
@@ -287,7 +287,7 @@ void VirusEditor::applyToSections(std::function<void(Component *)> action)
 }
 void VirusEditor::MainButtons::applyToMainButtons(std::function<void(DrawableButton *)> action)
 {
-    for (auto *section : {static_cast<juce::DrawableButton *>(&m_arpSettings), static_cast<DrawableButton *>(&m_effects),
+    for (auto *section : {static_cast<DrawableButton *>(&m_arpSettings), static_cast<DrawableButton *>(&m_effects),
                           static_cast<DrawableButton *>(&m_lfoMatrix), static_cast<DrawableButton *>(&m_oscFilter),
                           static_cast<DrawableButton *>(&m_patches)})
     {
@@ -299,58 +299,58 @@ void VirusEditor::updateControlLabel(Component* eventComponent) {
     auto props = eventComponent->getProperties();
     if(props.contains("type") && props["type"] == "slider") {
         m_controlLabel.setVisible(true);
-        auto comp = dynamic_cast<juce::Slider*>(eventComponent);
+        auto comp = dynamic_cast<Slider*>(eventComponent);
         if(comp) {
             auto name = props["name"];
             if(m_paramDisplayLocal) {
                 m_controlLabel.setTopLeftPosition(getTopLevelComponent()->getLocalPoint(comp->getParentComponent(), comp->getPosition().translated(0, -16)));
                 m_controlLabel.setSize(comp->getWidth(), 20);
-                m_controlLabel.setColour(juce::Label::ColourIds::backgroundColourId, juce::Colours::black);
-                m_controlLabel.setColour(juce::Label::ColourIds::outlineColourId, juce::Colours::white);
+                m_controlLabel.setColour(Label::ColourIds::backgroundColourId, Colours::black);
+                m_controlLabel.setColour(Label::ColourIds::outlineColourId, Colours::white);
                 if (props.contains("bipolar") && props["bipolar"]) {
-                    m_controlLabel.setText(juce::String(juce::roundToInt(comp->getValue())-64), juce::dontSendNotification);
+                    m_controlLabel.setText(String(roundToInt(comp->getValue())-64), dontSendNotification);
                 } else {
-                    m_controlLabel.setText(juce::String(juce::roundToInt(comp->getValue())), juce::dontSendNotification);
+                    m_controlLabel.setText(String(roundToInt(comp->getValue())), dontSendNotification);
                 }
             }
             else {
                 m_controlLabel.setBounds(m_patchName.getBounds().translated(m_controlLabel.getWidth(), 0));
                 m_controlLabel.setSize(m_patchName.getWidth()/2, m_patchName.getHeight());
                 if (props.contains("bipolar") && props["bipolar"]) {
-                    m_controlLabel.setText(name.toString() + "\n" + juce::String(juce::roundToInt(comp->getValue())-64), juce::dontSendNotification);
+                    m_controlLabel.setText(name.toString() + "\n" + String(roundToInt(comp->getValue())-64), dontSendNotification);
                 } else {
-                    m_controlLabel.setText(name.toString() + "\n" + juce::String(juce::roundToInt(comp->getValue())), juce::dontSendNotification);
+                    m_controlLabel.setText(name.toString() + "\n" + String(roundToInt(comp->getValue())), dontSendNotification);
                 }
             }
         }
     }
 }
-void VirusEditor::mouseDrag(const juce::MouseEvent & event)
+void VirusEditor::mouseDrag(const MouseEvent & event)
 {
     updateControlLabel(event.eventComponent);
 }
 
-void VirusEditor::mouseEnter(const juce::MouseEvent& event) {
+void VirusEditor::mouseEnter(const MouseEvent& event) {
     if (event.mouseWasDraggedSinceMouseDown()) {
         return;
     }
     updateControlLabel(event.eventComponent);
 }
-void VirusEditor::mouseExit(const juce::MouseEvent& event) {
+void VirusEditor::mouseExit(const MouseEvent& event) {
     if (event.mouseWasDraggedSinceMouseDown()) {
         return;
     }
-    m_controlLabel.setText("", juce::dontSendNotification);
+    m_controlLabel.setText("", dontSendNotification);
 }
-void VirusEditor::mouseDown(const juce::MouseEvent &event) {
+void VirusEditor::mouseDown(const MouseEvent &event) {
     
 }
-void VirusEditor::mouseUp(const juce::MouseEvent & event)
+void VirusEditor::mouseUp(const MouseEvent & event)
 {
-    m_controlLabel.setText("", juce::dontSendNotification);
+    m_controlLabel.setText("", dontSendNotification);
     m_controlLabel.setVisible(false);
 }
-void VirusEditor::mouseWheelMove(const juce::MouseEvent& event, const juce::MouseWheelDetails& wheel) {
+void VirusEditor::mouseWheelMove(const MouseEvent& event, const MouseWheelDetails& wheel) {
     updateControlLabel(event.eventComponent);
 }
 void VirusEditor::resized()
@@ -410,9 +410,9 @@ VirusEditor::MainButtons::MainButtons()
 }
 
 
-void VirusEditor::MainButtons::valueChanged(juce::Value &) { updateSection(); }
+void VirusEditor::MainButtons::valueChanged(Value &) { updateSection(); }
 
-void VirusEditor::MainButtons::setupButton (int i, std::unique_ptr<Drawable>&& btnImage, juce::DrawableButton& btn)
+void VirusEditor::MainButtons::setupButton (int i, std::unique_ptr<Drawable>&& btnImage, DrawableButton& btn)
 {
     auto onImage = btnImage->createCopy();
     onImage->setOriginWithOriginalSize({0, -kButtonHeight});
@@ -462,7 +462,7 @@ void VirusEditor::loadFile()
         const auto ext = result.getFileExtension().toLowerCase();
         if (ext == ".syx")
         {
-            juce::MemoryBlock data;
+            MemoryBlock data;
             result.loadFileAsData(data);
 
             for (auto it = data.begin(); it != data.end(); it += 267)
@@ -476,7 +476,7 @@ void VirusEditor::loadFile()
         }
         else if (ext == ".mid" || ext == ".midi")
         {
-            juce::MemoryBlock data;
+            MemoryBlock data;
             if (!result.loadFileAsData(data))
             {
                 return;
@@ -536,7 +536,7 @@ void VirusEditor::saveFile() {
     m_fileChooser = std::make_unique<FileChooser>(
         "Save preset as syx",
         m_previousPath.isEmpty()
-            ? (path.isEmpty() ? File::getSpecialLocation(juce::File::currentApplicationFile).getParentDirectory() : juce::File(path))
+            ? (path.isEmpty() ? File::getSpecialLocation(File::currentApplicationFile).getParentDirectory() : File(path))
             : m_previousPath,
         "*.syx", true);
     const auto flags = FileBrowserComponent::saveMode | FileBrowserComponent::FileChooserFlags::canSelectFiles;

--- a/source/jucePlugin/ui/VirusEditor.h
+++ b/source/jucePlugin/ui/VirusEditor.h
@@ -84,6 +84,8 @@ private:
     std::unique_ptr<Parts> m_partList;
     std::unique_ptr<juce::Drawable> m_background;
 
+    std::unique_ptr<juce::FileChooser> m_fileChooser;
+
     Virus::LookAndFeel m_lookAndFeel;
 
     juce::String m_previousPath;

--- a/source/jucePlugin/ui/Virus_FxEditor.cpp
+++ b/source/jucePlugin/ui/Virus_FxEditor.cpp
@@ -56,7 +56,7 @@ FxEditor::FxEditor(VirusParameterBinding &_parameterBinding, Virus::Controller& 
     if (p) {
         const auto val = (int)p->getValueObject().getValueSource().getValue();
         if (val > 1 && val < 5) {
-            m_fxMode.setSelectedId(val + 1, juce::dontSendNotification);
+            m_fxMode.setSelectedId(val + 1, dontSendNotification);
             const bool isReverb = (val > 1 && val < 5);
             m_reverb->setVisible(isReverb);
             m_delay->setVisible(!isReverb);
@@ -65,7 +65,7 @@ FxEditor::FxEditor(VirusParameterBinding &_parameterBinding, Virus::Controller& 
         p->onValueChanged = [this, p]() {
             rebind();
             const auto value = (int)p->getValueObject().getValueSource().getValue();
-            m_fxMode.setSelectedId(value + 1, juce::dontSendNotification);
+            m_fxMode.setSelectedId(value + 1, dontSendNotification);
             const bool isReverb = (value > 1 && value < 5);
             m_reverb->setVisible(isReverb);
             m_delay->setVisible(!isReverb);

--- a/source/jucePlugin/ui/Virus_LookAndFeel.cpp
+++ b/source/jucePlugin/ui/Virus_LookAndFeel.cpp
@@ -70,7 +70,7 @@ void LookAndFeel::drawComboBox (Graphics& g, int width, int height, bool isButto
 {
     // panels draws combo box... so it's invisible :)
 }
-void LookAndFeel::drawButtonBackground(juce::Graphics &, juce::Button &, const juce::Colour &backgroundColour, bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown)
+void LookAndFeel::drawButtonBackground(Graphics &, Button &, const Colour &backgroundColour, bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown)
 {
 
 }

--- a/source/jucePlugin/ui/Virus_Parts.cpp
+++ b/source/jucePlugin/ui/Virus_Parts.cpp
@@ -53,7 +53,7 @@ Parts::Parts(VirusParameterBinding & _parameterBinding, Virus::Controller& _cont
                 bankName << "Bank " << static_cast<char>('A' + b);
                 selector.addSubMenu(std::string(bankName.str()), p);
             }
-            selector.showMenu(juce::PopupMenu::Options());
+            selector.showMenuAsync(juce::PopupMenu::Options());
         };
         addAndMakeVisible(m_presetNames[pt]);
 

--- a/source/jucePlugin/ui/Virus_Parts.cpp
+++ b/source/jucePlugin/ui/Virus_Parts.cpp
@@ -12,14 +12,14 @@ Parts::Parts(VirusParameterBinding & _parameterBinding, Virus::Controller& _cont
     for (auto pt = 0; pt < 16; pt++)
     {
         m_partLabels[pt].setBounds(34, 161 + pt * (36), 24, 36);
-        m_partLabels[pt].setText(juce::String(pt + 1), juce::dontSendNotification);
-        m_partLabels[pt].setColour(0, juce::Colours::white);
-        m_partLabels[pt].setColour(1, juce::Colour(45, 24, 24));
+        m_partLabels[pt].setText(String(pt + 1), dontSendNotification);
+        m_partLabels[pt].setColour(0, Colours::white);
+        m_partLabels[pt].setColour(1, Colour(45, 24, 24));
         m_partLabels[pt].setJustificationType(Justification::centred);
         addAndMakeVisible(m_partLabels[pt]);
 
         m_partSelect[pt].setBounds(35, 161 + pt*(36), 36, 36);
-        m_partSelect[pt].setButtonText(juce::String(pt));
+        m_partSelect[pt].setButtonText(String(pt));
         m_partSelect[pt].setRadioGroupId(kPartGroupId);
         m_partSelect[pt].setClickingTogglesState(true);
         m_partSelect[pt].onClick = [this, pt]() {
@@ -29,17 +29,17 @@ Parts::Parts(VirusParameterBinding & _parameterBinding, Virus::Controller& _cont
 
         m_presetNames[pt].setBounds(80, 171 + pt * (36) - 2, 136, 16 + 4);
         m_presetNames[pt].setButtonText(m_controller.getCurrentPartPresetName(pt));
-        m_presetNames[pt].setColour(juce::TextButton::ColourIds::textColourOnId, juce::Colour(255,113,128));
-        m_presetNames[pt].setColour(juce::TextButton::ColourIds::textColourOffId, juce::Colour(255, 113, 128));
+        m_presetNames[pt].setColour(TextButton::ColourIds::textColourOnId, Colour(255,113,128));
+        m_presetNames[pt].setColour(TextButton::ColourIds::textColourOffId, Colour(255, 113, 128));
 
         m_presetNames[pt].onClick = [this, pt]() {
-            juce::PopupMenu selector;
+            PopupMenu selector;
 
             for (uint8_t b = 0; b < m_controller.getBankCount(); ++b)
             {
                 const auto bank = virusLib::fromArrayIndex(b);
                 auto presetNames = m_controller.getSinglePresetNames(bank);
-                juce::PopupMenu p;
+                PopupMenu p;
                 for (uint8_t j = 0; j < 128; j++)
                 {
                     const auto presetName = presetNames[j];
@@ -53,7 +53,7 @@ Parts::Parts(VirusParameterBinding & _parameterBinding, Virus::Controller& _cont
                 bankName << "Bank " << static_cast<char>('A' + b);
                 selector.addSubMenu(std::string(bankName.str()), p);
             }
-            selector.showMenuAsync(juce::PopupMenu::Options());
+            selector.showMenuAsync(PopupMenu::Options());
         };
         addAndMakeVisible(m_presetNames[pt]);
 
@@ -61,10 +61,10 @@ Parts::Parts(VirusParameterBinding & _parameterBinding, Virus::Controller& _cont
         m_nextPatch[pt].setBounds(247, 173 + 36*pt - 2, 16, 14);
         m_prevPatch[pt].setButtonText("<");
         m_nextPatch[pt].setButtonText(">");
-        m_prevPatch[pt].setColour(juce::TextButton::ColourIds::textColourOnId, juce::Colour(255, 113, 128));
-        m_nextPatch[pt].setColour(juce::TextButton::ColourIds::textColourOnId, juce::Colour(255, 113, 128));
-        m_prevPatch[pt].setColour(juce::TextButton::ColourIds::textColourOffId, juce::Colour(255, 113, 128));
-        m_nextPatch[pt].setColour(juce::TextButton::ColourIds::textColourOffId, juce::Colour(255, 113, 128));
+        m_prevPatch[pt].setColour(TextButton::ColourIds::textColourOnId, Colour(255, 113, 128));
+        m_nextPatch[pt].setColour(TextButton::ColourIds::textColourOnId, Colour(255, 113, 128));
+        m_prevPatch[pt].setColour(TextButton::ColourIds::textColourOffId, Colour(255, 113, 128));
+        m_nextPatch[pt].setColour(TextButton::ColourIds::textColourOffId, Colour(255, 113, 128));
         m_prevPatch[pt].onClick = [this, pt]() {
             m_controller.setCurrentPartPreset(
                 pt, m_controller.getCurrentPartBank(pt),
@@ -80,8 +80,8 @@ Parts::Parts(VirusParameterBinding & _parameterBinding, Virus::Controller& _cont
         addAndMakeVisible(m_prevPatch[pt]);
         addAndMakeVisible(m_nextPatch[pt]);
 
-        m_partVolumes[pt].setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
-        m_partVolumes[pt].setTextBoxStyle(juce::Slider::NoTextBox, false, 0, 0);
+        m_partVolumes[pt].setSliderStyle(Slider::RotaryHorizontalVerticalDrag);
+        m_partVolumes[pt].setTextBoxStyle(Slider::NoTextBox, false, 0, 0);
         m_partVolumes[pt].setBounds(m_nextPatch[pt].getBounds().translated(m_nextPatch[pt].getWidth()+8, 0));
         m_partVolumes[pt].setSize(18,18);
         m_partVolumes[pt].getProperties().set(Virus::LookAndFeel::KnobStyleProp, Virus::LookAndFeel::KnobStyle::GENERIC_MULTI);
@@ -89,8 +89,8 @@ Parts::Parts(VirusParameterBinding & _parameterBinding, Virus::Controller& _cont
         _parameterBinding.bind(m_partVolumes[pt], Virus::Param_PartVolume, pt);
         addAndMakeVisible(m_partVolumes[pt]);
 
-        m_partPans[pt].setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
-        m_partPans[pt].setTextBoxStyle(juce::Slider::NoTextBox, false, 0, 0);
+        m_partPans[pt].setSliderStyle(Slider::RotaryHorizontalVerticalDrag);
+        m_partPans[pt].setTextBoxStyle(Slider::NoTextBox, false, 0, 0);
         m_partPans[pt].setBounds(m_partVolumes[pt].getBounds().translated(m_partVolumes[pt].getWidth()+4, 0));
         m_partPans[pt].setSize(18,18);
         m_partPans[pt].getProperties().set(Virus::LookAndFeel::KnobStyleProp, Virus::LookAndFeel::KnobStyle::GENERIC_MULTI);
@@ -109,12 +109,12 @@ Parts::Parts(VirusParameterBinding & _parameterBinding, Virus::Controller& _cont
     m_btSingleMode.setTopLeftPosition(102, 756);
     m_btSingleMode.setSize(103, 30);
 
-    m_btSingleMode.setColour(TextButton::ColourIds::textColourOnId, juce::Colours::white);
-    m_btSingleMode.setColour(TextButton::ColourIds::textColourOffId, juce::Colours::grey);
-    m_btMultiMode.setColour(TextButton::ColourIds::textColourOnId, juce::Colours::white);
-    m_btMultiMode.setColour(TextButton::ColourIds::textColourOffId, juce::Colours::grey);
-    m_btMultiSingleMode.setColour(TextButton::ColourIds::textColourOnId, juce::Colours::white);
-    m_btMultiSingleMode.setColour(TextButton::ColourIds::textColourOffId, juce::Colours::grey);
+    m_btSingleMode.setColour(TextButton::ColourIds::textColourOnId, Colours::white);
+    m_btSingleMode.setColour(TextButton::ColourIds::textColourOffId, Colours::grey);
+    m_btMultiMode.setColour(TextButton::ColourIds::textColourOnId, Colours::white);
+    m_btMultiMode.setColour(TextButton::ColourIds::textColourOffId, Colours::grey);
+    m_btMultiSingleMode.setColour(TextButton::ColourIds::textColourOnId, Colours::white);
+    m_btMultiSingleMode.setColour(TextButton::ColourIds::textColourOffId, Colours::grey);
     m_btSingleMode.onClick = [this]() { setPlayMode(virusLib::PlayMode::PlayModeSingle); };
     m_btMultiSingleMode.onClick = [this]() { setPlayMode(virusLib::PlayMode::PlayModeMultiSingle); };
     m_btMultiMode.onClick = [this]() { setPlayMode(virusLib::PlayMode::PlayModeMulti); };
@@ -134,15 +134,15 @@ void Parts::updatePlayModeButtons()
     const auto _mode = (int)modeParam->getValue();
     if (_mode == virusLib::PlayModeSingle)
     {
-        m_btSingleMode.setToggleState(true, juce::dontSendNotification);
+        m_btSingleMode.setToggleState(true, dontSendNotification);
     }
     /*else if (_mode == virusLib::PlayModeMultiSingle) // disabled for now
     {
-        m_btMultiSingleMode.setToggleState(true, juce::dontSendNotification);
+        m_btMultiSingleMode.setToggleState(true, dontSendNotification);
     }*/
     else if (_mode == virusLib::PlayModeMulti || _mode == virusLib::PlayModeMultiSingle)
     {
-        m_btMultiMode.setToggleState(true, juce::dontSendNotification);
+        m_btMultiMode.setToggleState(true, dontSendNotification);
     }
 }
 void Parts::refreshParts() {
@@ -162,9 +162,9 @@ void Parts::changePart(uint8_t _part)
     {
     for (auto &p : m_partSelect)
     {
-        p.setToggleState(false, juce::dontSendNotification);
+        p.setToggleState(false, dontSendNotification);
     }
-    m_partSelect[_part].setToggleState(true, juce::dontSendNotification);
+    m_partSelect[_part].setToggleState(true, dontSendNotification);
     m_parameterBinding.setPart(_part);
     getParentComponent()->postCommandMessage(VirusEditor::Commands::UpdateParts);
     getParentComponent()->postCommandMessage(VirusEditor::Commands::Rebind);

--- a/source/jucePlugin/ui/Virus_PatchBrowser.cpp
+++ b/source/jucePlugin/ui/Virus_PatchBrowser.cpp
@@ -8,7 +8,7 @@
 using namespace juce;
 using namespace virusLib;
 constexpr auto comboBoxWidth = 98;
-const juce::Array<juce::String> categories = {"", "Lead",	 "Bass",	  "Pad",	   "Decay",	   "Pluck",
+const Array<String> categories = {"", "Lead",	 "Bass",	  "Pad",	   "Decay",	   "Pluck",
                              "Acid", "Classic", "Arpeggiator", "Effects",	"Drums",	"Percussion",
                              "Input", "Vocoder", "Favourite 1", "Favourite 2", "Favourite 3"};
 
@@ -23,7 +23,7 @@ PatchBrowser::PatchBrowser(VirusParameterBinding & _parameterBinding, Virus::Con
     m_properties = m_controller.getConfig();
     
     auto bankDir = m_properties->getValue("virus_bank_dir", "");
-    if (bankDir != "" && juce::File(bankDir).isDirectory())
+    if (bankDir != "" && File(bankDir).isDirectory())
     {
         m_bankList.setRoot(bankDir);
     }
@@ -45,7 +45,7 @@ PatchBrowser::PatchBrowser(VirusParameterBinding & _parameterBinding, Virus::Con
     addAndMakeVisible(m_patchList);
 
     m_search.setSize(m_patchList.getWidth(), 20);
-    m_search.setColour(TextEditor::textColourId, juce::Colours::white);
+    m_search.setColour(TextEditor::textColourId, Colours::white);
     m_search.setTopLeftPosition(m_patchList.getBounds().getBottomLeft().translated(0, 8));
     m_search.onTextChange = [this] {
         m_filteredPatches.clear();
@@ -62,7 +62,7 @@ PatchBrowser::PatchBrowser(VirusParameterBinding & _parameterBinding, Virus::Con
         m_patchList.deselectAllRows();
         m_patchList.repaint();
     };
-    m_search.setTextToShowWhenEmpty("search...", juce::Colours::grey);
+    m_search.setTextToShowWhenEmpty("search...", Colours::grey);
     addAndMakeVisible(m_search);
     m_bankList.addListener(this);
     m_patchList.setModel(this);
@@ -89,14 +89,14 @@ VirusModel guessVersion(uint8_t *data) {
     return VirusModel::C;
 
 }
-int PatchBrowser::loadBankFile(const juce::File& file, const int _startIndex = 0, const bool dedupe = false) {
+int PatchBrowser::loadBankFile(const File& file, const int _startIndex = 0, const bool dedupe = false) {
     auto ext = file.getFileExtension().toLowerCase();
     auto path = file.getParentDirectory().getFullPathName();
     int loadedCount = 0;
     int index = _startIndex;
     if (ext == ".syx")
     {
-        juce::MemoryBlock data;
+        MemoryBlock data;
         if (!file.loadFileAsData(data)) {
             return 0;
         }
@@ -123,7 +123,7 @@ int PatchBrowser::loadBankFile(const juce::File& file, const int _startIndex = 0
                 else {
                     patch.model = guessVersion(patch.data);
                 }
-                auto md5 = juce::MD5(it+9 + 17, 256-17-3).toHexString();
+                auto md5 = MD5(it+9 + 17, 256-17-3).toHexString();
                 if(!dedupe || !m_checksums.contains(md5)) {
                     m_checksums.set(md5, true);
                     m_patches.add(patch);
@@ -134,7 +134,7 @@ int PatchBrowser::loadBankFile(const juce::File& file, const int _startIndex = 0
     }
     else if (ext == ".mid" || ext == ".midi")
     {
-        juce::MemoryBlock data;
+        MemoryBlock data;
         if (!file.loadFileAsData(data))
         {
             return 0;
@@ -171,7 +171,7 @@ int PatchBrowser::loadBankFile(const juce::File& file, const int _startIndex = 0
                     else {
                         patch.model = guessVersion(patch.data);
                     }
-                    auto md5 = juce::MD5(it+9 + 17, 256-17-3).toHexString();
+                    auto md5 = MD5(it+9 + 17, 256-17-3).toHexString();
                     if(!dedupe || !m_checksums.contains(md5)) {
                         m_checksums.set(md5, true);
                         m_patches.add(patch);
@@ -209,7 +209,7 @@ int PatchBrowser::loadBankFile(const juce::File& file, const int _startIndex = 0
                     else {
                         patch.model = guessVersion(patch.data);
                     }
-                    auto md5 = juce::MD5(it+2+9 + 17, 256-17-3).toHexString();
+                    auto md5 = MD5(it+2+9 + 17, 256-17-3).toHexString();
                     if(!dedupe || !m_checksums.contains(md5)) {
                         m_checksums.set(md5, true);
                         m_patches.add(patch);
@@ -225,17 +225,17 @@ int PatchBrowser::loadBankFile(const juce::File& file, const int _startIndex = 0
     return index;
 }
 
-void PatchBrowser::fileClicked(const juce::File &file, const juce::MouseEvent &e)
+void PatchBrowser::fileClicked(const File &file, const MouseEvent &e)
 {
     auto ext = file.getFileExtension().toLowerCase();
     auto path = file.getParentDirectory().getFullPathName();
     if (file.isDirectory() && e.mods.isRightButtonDown()) {
-        auto p = juce::PopupMenu();
+        auto p = PopupMenu();
         p.addItem("Add directory contents to patch list", [this, file]() {
             m_patches.clear();
             m_checksums.clear();
             int lastIndex = 0;
-            for (auto f : juce::RangedDirectoryIterator(file, false, "*.syx;*.mid;*.midi", juce::File::findFiles)) {
+            for (auto f : RangedDirectoryIterator(file, false, "*.syx;*.mid;*.midi", File::findFiles)) {
                 lastIndex = loadBankFile(f.getFile(), lastIndex, true);
             }
             m_filteredPatches.clear();
@@ -252,7 +252,7 @@ void PatchBrowser::fileClicked(const juce::File &file, const juce::MouseEvent &e
             m_patchList.deselectAllRows();
             m_patchList.repaint();    
         });
-        p.showMenuAsync(juce::PopupMenu::Options());
+        p.showMenuAsync(PopupMenu::Options());
         
         return;
     }
@@ -277,7 +277,7 @@ void PatchBrowser::fileClicked(const juce::File &file, const juce::MouseEvent &e
 
 }
 
-void PatchBrowser::fileDoubleClicked(const juce::File &file) {}
+void PatchBrowser::fileDoubleClicked(const File &file) {}
 
 void PatchBrowser::browserRootChanged(const File &newRoot) {}
 
@@ -285,23 +285,23 @@ int PatchBrowser::getNumRows() { return m_filteredPatches.size(); }
 
 void PatchBrowser::paintRowBackground(Graphics &g, int rowNumber, int width, int height, bool rowIsSelected) {
     auto alternateColour = getLookAndFeel()
-                               .findColour(juce::ListBox::backgroundColourId)
-                               .interpolatedWith(getLookAndFeel().findColour(juce::ListBox::textColourId), 0.03f);
+                               .findColour(ListBox::backgroundColourId)
+                               .interpolatedWith(getLookAndFeel().findColour(ListBox::textColourId), 0.03f);
     if (rowIsSelected)
-        g.fillAll(juce::Colours::lightblue);
+        g.fillAll(Colours::lightblue);
     else if (rowNumber % 2)
         g.fillAll(alternateColour);
 }
 
 void PatchBrowser::paintCell(Graphics &g, int rowNumber, int columnId, int width, int height, bool rowIsSelected) {
-    g.setColour(rowIsSelected ? juce::Colours::darkblue
-                                : getLookAndFeel().findColour(juce::ListBox::textColourId)); // [5]
+    g.setColour(rowIsSelected ? Colours::darkblue
+                                : getLookAndFeel().findColour(ListBox::textColourId)); // [5]
     
     auto rowElement = m_filteredPatches[rowNumber];
     //auto text = rowElement.name;
-    juce::String text = "";
+    String text = "";
     if (columnId == Columns::INDEX)
-        text = juce::String(rowElement.progNumber);
+        text = String(rowElement.progNumber);
     else if (columnId == Columns::NAME)
         text = rowElement.name;
     else if (columnId == Columns::CAT1)
@@ -311,15 +311,15 @@ void PatchBrowser::paintCell(Graphics &g, int rowNumber, int columnId, int width
     else if (columnId == Columns::ARP)
         text = rowElement.data[129] != 0 ? "Y" : " ";
     else if(columnId == Columns::UNI)
-        text = rowElement.unison == 0 ? " " : juce::String(rowElement.unison+1);
+        text = rowElement.unison == 0 ? " " : String(rowElement.unison+1);
     else if(columnId == Columns::ST)
-        text = rowElement.transpose != 64 ? juce::String(rowElement.transpose - 64) : " ";
+        text = rowElement.transpose != 64 ? String(rowElement.transpose - 64) : " ";
     else if (columnId == Columns::VER) {
         if(rowElement.model < ModelList.size())
             text = ModelList[rowElement.model];
     }
-    g.drawText(text, 2, 0, width - 4, height, juce::Justification::centredLeft, true); // [6]
-    g.setColour(getLookAndFeel().findColour(juce::ListBox::backgroundColourId));
+    g.drawText(text, 2, 0, width - 4, height, Justification::centredLeft, true); // [6]
+    g.setColour(getLookAndFeel().findColour(ListBox::backgroundColourId));
     g.fillRect(width - 1, 0, 1, height); // [7]
 }
 
@@ -355,7 +355,7 @@ void PatchBrowser::selectedRowsChanged(int lastRowSelected) {
     getParentComponent()->postCommandMessage(VirusEditor::Commands::UpdateParts);
 }
 
-void PatchBrowser::cellDoubleClicked(int rowNumber, int columnId, const juce::MouseEvent &)
+void PatchBrowser::cellDoubleClicked(int rowNumber, int columnId, const MouseEvent &)
 {
     if(rowNumber == m_patchList.getSelectedRow()) {
         selectedRowsChanged(0);

--- a/source/jucePlugin/ui/Virus_PatchBrowser.cpp
+++ b/source/jucePlugin/ui/Virus_PatchBrowser.cpp
@@ -252,7 +252,7 @@ void PatchBrowser::fileClicked(const juce::File &file, const juce::MouseEvent &e
             m_patchList.deselectAllRows();
             m_patchList.repaint();    
         });
-        p.showMenu(juce::PopupMenu::Options());
+        p.showMenuAsync(juce::PopupMenu::Options());
         
         return;
     }

--- a/source/jucePlugin/ui2/VirusEditor.cpp
+++ b/source/jucePlugin/ui2/VirusEditor.cpp
@@ -84,7 +84,7 @@ VirusEditor::VirusEditor(VirusParameterBinding &_parameterBinding, AudioPluginAu
     {
         if (currentTab == index) 
         {
-            s->setToggleState(true, juce::dontSendNotification);
+            s->setToggleState(true, dontSendNotification);
         }
         index++;
     });
@@ -95,21 +95,21 @@ VirusEditor::VirusEditor(VirusParameterBinding &_parameterBinding, AudioPluginAu
     //MainDisplay (Patchname)
     m_patchName.setBounds(1473, 35, 480, 58);
     m_patchName.setJustificationType(Justification::left);
-    m_patchName.setFont(juce::Font("Register", "Normal", 30.f));
+    m_patchName.setFont(Font("Register", "Normal", 30.f));
     m_patchName.setEditable(false, true, true);
     addAndMakeVisible(m_patchName);
 
     //MainDisplay 
     m_controlLabel.setBounds(1473, 35, 650, 58);
-    m_controlLabel.setFont(juce::Font("Register", "Normal", 30.f));
+    m_controlLabel.setFont(Font("Register", "Normal", 30.f));
     addAndMakeVisible(m_controlLabel);
 
     //ToolTip
     //m_ToolTip.setLookAndFeel(&m_landfToolTip);
     m_ToolTip.setBounds(200, 50, 200, 200);
-    m_ToolTip.setFont(juce::Font("Register", "Normal", 15.f));
-    m_ToolTip.setColour(juce::Label::ColourIds::backgroundColourId, juce::Colours::black);
-    m_ToolTip.setColour(juce::Label::ColourIds::textColourId, juce::Colours::white);
+    m_ToolTip.setFont(Font("Register", "Normal", 15.f));
+    m_ToolTip.setColour(Label::ColourIds::backgroundColourId, Colours::black);
+    m_ToolTip.setColour(Label::ColourIds::textColourId, Colours::white);
     m_ToolTip.setJustificationType(Justification::centred);
     m_ToolTip.setAlpha(0.90);
     addAndMakeVisible(m_ToolTip);
@@ -118,8 +118,8 @@ VirusEditor::VirusEditor(VirusParameterBinding &_parameterBinding, AudioPluginAu
     //MainDisplay Value
     m_controlLabelValue.setBounds(1900, 35, 197, 58);
     m_controlLabelValue.setJustificationType(Justification::centredRight);
-    //m_controlLabelValue.setColour(juce::Label::textColourId, juce::Colours::red);
-    m_controlLabelValue.setFont(juce::Font("Register", "Normal", 30.f));
+    //m_controlLabelValue.setColour(Label::textColourId, Colours::red);
+    m_controlLabelValue.setFont(Font("Register", "Normal", 30.f));
     addAndMakeVisible(m_controlLabelValue); 
 
     //PresetsSwitch
@@ -142,8 +142,8 @@ VirusEditor::VirusEditor(VirusParameterBinding &_parameterBinding, AudioPluginAu
     //Show Version
     m_version.setText(std::string(g_pluginVersionString), NotificationType::dontSendNotification);
     m_version.setBounds(250, 1123, 50, 17);
-    m_version.setColour(juce::Label::textColourId, juce::Colours::silver);
-    m_version.setFont(juce::Font("Arial", "Bold", 20.f));
+    m_version.setColour(Label::textColourId, Colours::silver);
+    m_version.setFont(Font("Arial", "Bold", 20.f));
     m_version.setJustificationType(Justification::left);
     m_version.setJustificationType(Justification::centred);
     addAndMakeVisible(m_version);
@@ -151,25 +151,25 @@ VirusEditor::VirusEditor(VirusParameterBinding &_parameterBinding, AudioPluginAu
     //Show Synth Model
     m_SynthModel.setText(m_controller.getVirusModel() == virusLib::VirusModel::B ? "B" : "C", NotificationType::dontSendNotification);
     m_SynthModel.setBounds(430, 1123, 50, 17);
-    m_SynthModel.setFont(juce::Font("Arial", "Bold", 20.f));
+    m_SynthModel.setFont(Font("Arial", "Bold", 20.f));
     m_SynthModel.setJustificationType(Justification::left);
-    m_SynthModel.setColour(juce::Label::textColourId, juce::Colours::silver);
+    m_SynthModel.setColour(Label::textColourId, Colours::silver);
     m_SynthModel.setJustificationType(Justification::centred);
     addAndMakeVisible(m_SynthModel);
 
     //Show RomName
     m_RomName.setText(_processorRef.getRomName()+".bin", NotificationType::dontSendNotification);
     m_RomName.setBounds(642, 1123, 150, 17);
-    m_RomName.setColour(juce::Label::textColourId, juce::Colours::silver);
-    m_RomName.setFont(juce::Font("Arial", "Bold", 20.f));
+    m_RomName.setColour(Label::textColourId, Colours::silver);
+    m_RomName.setFont(Font("Arial", "Bold", 20.f));
     m_RomName.setJustificationType(Justification::left);
     m_RomName.setJustificationType(Justification::centred);
     addAndMakeVisible(m_RomName);
 
     //Hyperlink
     m_hyperLink.setBounds(900, 1115, 400, 35);
-    m_hyperLink.setColour(juce::Label::textColourId, juce::Colours::silver);
-    m_hyperLink.setFont(juce::Font("Arial", "Bold", 20.f), true, dontSendNotification);
+    m_hyperLink.setColour(Label::textColourId, Colours::silver);
+    m_hyperLink.setFont(Font("Arial", "Bold", 20.f), true, dontSendNotification);
     m_hyperLink.setJustificationType(Justification::left);
     m_hyperLink.setJustificationType(Justification::centred);
     addAndMakeVisible(m_hyperLink);
@@ -229,9 +229,9 @@ void VirusEditor::updateParts()
         {
             if (m_patchBrowser->GetIsFileMode())
 			{
-                m_patchName.setText("["+juce::String(m_controller.getCurrentPart()+1)
+                m_patchName.setText("["+String(m_controller.getCurrentPart()+1)
                     +"][FILE] "                    
-                    + juce::String(m_patchBrowser->GetTablePatchList()->getSelectedRow(0)+1)+": " + m_patchBrowser->GetLastPatchSelected(), dontSendNotification);
+                    + String(m_patchBrowser->GetTablePatchList()->getSelectedRow(0)+1)+": " + m_patchBrowser->GetLastPatchSelected(), dontSendNotification);
             }
 			else
 			{
@@ -239,9 +239,9 @@ void VirusEditor::updateParts()
                 if(m_patchName.getText() != patchName) 
                 {
                     String sZero;
-                    m_patchName.setText("["+juce::String(m_controller.getCurrentPart()+1)
+                    m_patchName.setText("["+String(m_controller.getCurrentPart()+1)
                         +"][" + m_patchBrowser->GetSelectBankNum() + "] "                    
-                        + juce::String(processorRef.getController().getCurrentPartProgram(m_controller.getCurrentPart())+1)+": " + patchName, dontSendNotification);
+                        + String(processorRef.getController().getCurrentPartProgram(m_controller.getCurrentPart())+1)+": " + patchName, dontSendNotification);
                 } 
             }
         }
@@ -267,14 +267,14 @@ void VirusEditor::ShowMainMenue()
 				double dScaleFactor = float(d / 1000.0);               
 	            m_AudioPlugInEditor->setScaleFactor(dScaleFactor);
 	            (*this).setSize(iSkinSizeWidth, iSkinSizeHeight);                
-                m_properties->setValue("skin_scale_factor", juce::String(dScaleFactor));
+                m_properties->setValue("skin_scale_factor", String(dScaleFactor));
                 m_properties->save();
             });
 		}        
               
         selectorMenu.addSubMenu("Skin size", SubSkinSizeSelector, true);
 		selectorMenu.addItem("About", [this]() { AboutWindow(); });
-        selectorMenu.showMenu(juce::PopupMenu::Options());
+        selectorMenu.showMenu(PopupMenu::Options());
 	};
 
     //draw Main Menu Button	
@@ -295,7 +295,7 @@ void VirusEditor::applyToSections(std::function<void(Component *)> action)
 
 void VirusEditor::MainButtons::applyToMainButtons(std::function<void(DrawableButton *)> action)
 {
-    for (auto *section : {static_cast<juce::DrawableButton *>(&m_arpSettings), static_cast<DrawableButton *>(&m_effects),
+    for (auto *section : {static_cast<DrawableButton *>(&m_arpSettings), static_cast<DrawableButton *>(&m_effects),
                           static_cast<DrawableButton *>(&m_lfoMatrix), static_cast<DrawableButton *>(&m_oscFilter),
                           static_cast<DrawableButton *>(&m_patches)})
     {
@@ -309,14 +309,14 @@ void VirusEditor::updateControlLabel(Component* eventComponent)
     auto props = eventComponent->getProperties();
     if(props.contains("type") && props["type"] == "slider") {
         
-        auto comp = dynamic_cast<juce::Slider*>(eventComponent);
+        auto comp = dynamic_cast<Slider*>(eventComponent);
         if(comp && comp->isEnabled()) 
         {
-            int iValue = (props.contains("bipolar") && props["bipolar"])?juce::roundToInt(comp->getValue())-64:juce::roundToInt(comp->getValue());
+            int iValue = (props.contains("bipolar") && props["bipolar"])?roundToInt(comp->getValue())-64:roundToInt(comp->getValue());
             
             //ToolTip handle
             m_ToolTip.setVisible(true);
-            m_ToolTip.setText(std::to_string(iValue), juce::dontSendNotification);
+            m_ToolTip.setText(std::to_string(iValue), dontSendNotification);
             //todo --> ugly --> Need to be fixed
             m_ToolTip.setBounds(comp->getX()+comp->getWidth()*2-43, comp->getY()+comp->getHeight()*2+83, 70,30);
             m_ToolTip.toFront(true);
@@ -328,22 +328,22 @@ void VirusEditor::updateControlLabel(Component* eventComponent)
 
             if(m_paramDisplayLocal) 
             {
-                m_controlLabel.setColour(juce::Label::ColourIds::backgroundColourId, juce::Colours::black);
-                m_controlLabel.setColour(juce::Label::ColourIds::outlineColourId, juce::Colours::white); 
+                m_controlLabel.setColour(Label::ColourIds::backgroundColourId, Colours::black);
+                m_controlLabel.setColour(Label::ColourIds::outlineColourId, Colours::white);
             }
 
-            m_controlLabel.setText(props["name"].toString(), juce::dontSendNotification);
-            m_controlLabelValue.setText(juce::String(iValue), juce::dontSendNotification);
+            m_controlLabel.setText(props["name"].toString(), dontSendNotification);
+            m_controlLabelValue.setText(String(iValue), dontSendNotification);
         }
     }
 
 }
-void VirusEditor::mouseDrag(const juce::MouseEvent & event)
+void VirusEditor::mouseDrag(const MouseEvent & event)
 {
     updateControlLabel(event.eventComponent);
 }
 
-void VirusEditor::mouseEnter(const juce::MouseEvent& event) 
+void VirusEditor::mouseEnter(const MouseEvent& event)
 {
     if (event.mouseWasDraggedSinceMouseDown()) {
         return;
@@ -351,31 +351,31 @@ void VirusEditor::mouseEnter(const juce::MouseEvent& event)
     updateControlLabel(event.eventComponent);
 }
 
-void VirusEditor::mouseExit(const juce::MouseEvent& event) 
+void VirusEditor::mouseExit(const MouseEvent& event)
 {
     if (event.mouseWasDraggedSinceMouseDown()) {
         return;
     }
-    m_controlLabel.setText("", juce::dontSendNotification);
+    m_controlLabel.setText("", dontSendNotification);
     m_controlLabel.setVisible(false); 
     m_controlLabelValue.setVisible(false);
     m_patchName.setVisible(true);
     m_ToolTip.setVisible(false);
 }
 
-void VirusEditor::mouseDown(const juce::MouseEvent &event) 
+void VirusEditor::mouseDown(const MouseEvent &event)
 {
 }
 
-void VirusEditor::mouseUp(const juce::MouseEvent & event)
+void VirusEditor::mouseUp(const MouseEvent & event)
 {
-    m_controlLabel.setText("", juce::dontSendNotification);
+    m_controlLabel.setText("", dontSendNotification);
     m_controlLabel.setVisible(false); 
     m_controlLabelValue.setVisible(false);
     m_patchName.setVisible(true);
     m_ToolTip.setVisible(false);
 }
-void VirusEditor::mouseWheelMove(const juce::MouseEvent& event, const juce::MouseWheelDetails& wheel) 
+void VirusEditor::mouseWheelMove(const MouseEvent& event, const MouseWheelDetails& wheel)
 {
     updateControlLabel(event.eventComponent);
 }
@@ -472,9 +472,9 @@ VirusEditor::MainButtons::MainButtons()
 }
 
 
-void VirusEditor::MainButtons::valueChanged(juce::Value &) { updateSection(); }
+void VirusEditor::MainButtons::valueChanged(Value &) { updateSection(); }
 
-void VirusEditor::MainButtons::setupButton (int i, std::unique_ptr<Drawable>&& btnImage, juce::DrawableButton& btn)
+void VirusEditor::MainButtons::setupButton (int i, std::unique_ptr<Drawable>&& btnImage, DrawableButton& btn)
 {
     auto onImage = btnImage->createCopy();
     onImage->setOriginWithOriginalSize({0, -kButtonHeight});

--- a/source/jucePlugin/ui2/Virus_LookAndFeel.cpp
+++ b/source/jucePlugin/ui2/Virus_LookAndFeel.cpp
@@ -5,10 +5,10 @@ using namespace juce;
 
 namespace Virus
 {
-    const juce::Font getCustomFont()
+    const Font getCustomFont()
     {
-        static auto typefaceDigiFont = juce::Typeface::createSystemTypefaceFor(BinaryData::Digital, BinaryData::DigitalSize);  
-        return juce::Font (typefaceDigiFont);
+        static auto typefaceDigiFont = Typeface::createSystemTypefaceFor(BinaryData::Digital, BinaryData::DigitalSize);
+        return Font (typefaceDigiFont);
     }
 
 	//LookAndFeel
@@ -58,10 +58,10 @@ namespace Virus
 		knob->drawAt(g, x, y, 1.0f);
 	}
 
-    void LookAndFeel::drawComboBox (juce::Graphics& gGrafik, int width, int height, bool isButtonDown, int buttonX, int buttonY, int buttonW, int buttonH, juce::ComboBox& box)
+    void LookAndFeel::drawComboBox (Graphics& gGrafik, int width, int height, bool isButtonDown, int buttonX, int buttonY, int buttonW, int buttonH, ComboBox& box)
     {
         //gGrafik.setOpacity(0);
-        //box.setColour(juce::ComboBox::textColourId, juce::Colours::red);
+        //box.setColour(ComboBox::textColourId, Colours::red);
     };
 
 	//LookAndFeelPatchBrowser
@@ -74,7 +74,7 @@ namespace Virus
 	{
 	}
 
-    void LookAndFeelButtons::drawComboBox (juce::Graphics& gGrafik, int width, int height, bool isButtonDown, int buttonX, int buttonY, int buttonW, int buttonH, juce::ComboBox& box)
+    void LookAndFeelButtons::drawComboBox (Graphics& gGrafik, int width, int height, bool isButtonDown, int buttonX, int buttonY, int buttonW, int buttonH, ComboBox& box)
     {
         gGrafik.setOpacity(0);
     };

--- a/source/jucePlugin/ui2/Virus_LookAndFeel.h
+++ b/source/jucePlugin/ui2/Virus_LookAndFeel.h
@@ -17,8 +17,6 @@ constexpr auto kPanelHeight = 1152;
 
 constexpr auto comboBoxXMargin = 5;
 
-using namespace juce;
-
 namespace Virus
 {
     const juce::Font getCustomFont();

--- a/source/jucePlugin/ui2/Virus_Panel3_FxEditor.cpp
+++ b/source/jucePlugin/ui2/Virus_Panel3_FxEditor.cpp
@@ -272,7 +272,7 @@ void FxEditor::Vocoder()
 	//m_vocoderMode
 	auto p = m_controller.getParameter(Virus::Param_VocoderMode, 0);
     const auto value = (int)p->getValueObject().getValueSource().getValue();
-    m_vocoderMode.setSelectedId(value + 1, juce::dontSendNotification);
+    m_vocoderMode.setSelectedId(value + 1, dontSendNotification);
 
 	int iSelectedIndex = m_vocoderMode.getSelectedItemIndex();
 	bool bVocoder = (iSelectedIndex > 0); 
@@ -312,7 +312,7 @@ void FxEditor::DelayReverb()
     //rebind();
 	auto p = m_controller.getParameter(Virus::Param_DelayReverbMode, 0);
     const auto value = (int)p->getValueObject().getValueSource().getValue();
-    m_delayReverbMode.setSelectedId(value + 1, juce::dontSendNotification);
+    m_delayReverbMode.setSelectedId(value + 1, dontSendNotification);
 
 	//Delay/Reverb
 	int iSelectedIndex = m_delayReverbMode.getSelectedItemIndex();

--- a/source/jucePlugin/ui2/Virus_Panel4_ArpEditor.cpp
+++ b/source/jucePlugin/ui2/Virus_Panel4_ArpEditor.cpp
@@ -130,8 +130,8 @@ ArpEditor::ArpEditor(VirusParameterBinding &_parameterBinding, AudioPluginAudioP
         addAndMakeVisible(m_partSelect[pt]);
 
         m_presetNames[pt].setBounds(245 - 225/2 + iMarginXChannels, 97 - 70/2 + iIndex * (iMarginYChannels), 225, 70);
-        m_presetNames[pt].setText(m_controller.getCurrentPartPresetName(pt),  juce::dontSendNotification);
-        m_presetNames[pt].setFont(juce::Font("Register", "Normal", 23.f));
+        m_presetNames[pt].setText(m_controller.getCurrentPartPresetName(pt),  dontSendNotification);
+        m_presetNames[pt].setFont(Font("Register", "Normal", 23.f));
         m_presetNames[pt].setJustificationType(Justification::left);
  
         addAndMakeVisible(m_presetNames[pt]);
@@ -188,8 +188,8 @@ ArpEditor::~ArpEditor()
 void ArpEditor::MidiInit() 
 {
     //MIDI settings
-    juce::String midiIn = m_properties->getValue("midi_input", "");
-    juce::String midiOut = m_properties->getValue("midi_output", "");
+    String midiIn = m_properties->getValue("midi_input", "");
+    String midiOut = m_properties->getValue("midi_output", "");
     
     if (midiIn != "")
     {
@@ -207,8 +207,8 @@ void ArpEditor::MidiInit()
     addAndMakeVisible(m_cmbMidiOutput);
 
     m_cmbMidiInput.setTextWhenNoChoicesAvailable("No MIDI Inputs Enabled");
-    auto midiInputs = juce::MidiInput::getAvailableDevices();
-    juce::StringArray midiInputNames;
+    auto midiInputs = MidiInput::getAvailableDevices();
+    StringArray midiInputNames;
     midiInputNames.add(" - Midi In - ");
     auto inIndex = 0;
 
@@ -223,10 +223,10 @@ void ArpEditor::MidiInit()
     }
 
     m_cmbMidiInput.addItemList(midiInputNames, 1);
-    m_cmbMidiInput.setSelectedItemIndex(inIndex, juce::dontSendNotification);
+    m_cmbMidiInput.setSelectedItemIndex(inIndex, dontSendNotification);
     m_cmbMidiOutput.setTextWhenNoChoicesAvailable("No MIDI Outputs Enabled");
-    auto midiOutputs = juce::MidiOutput::getAvailableDevices();
-    juce::StringArray midiOutputNames;
+    auto midiOutputs = MidiOutput::getAvailableDevices();
+    StringArray midiOutputNames;
     midiOutputNames.add(" - Midi Out - ");
     auto outIndex = 0;
     
@@ -242,7 +242,7 @@ void ArpEditor::MidiInit()
     }
 
     m_cmbMidiOutput.addItemList(midiOutputNames, 1);
-    m_cmbMidiOutput.setSelectedItemIndex(outIndex, juce::dontSendNotification);
+    m_cmbMidiOutput.setSelectedItemIndex(outIndex, dontSendNotification);
     m_cmbMidiInput.onChange = [this]() { updateMidiInput(m_cmbMidiInput.getSelectedItemIndex()); };
     m_cmbMidiOutput.onChange = [this]() { updateMidiOutput(m_cmbMidiOutput.getSelectedItemIndex()); };
 }
@@ -268,9 +268,9 @@ void ArpEditor::refreshParts()
             m_presetNames[pt].setAlpha(fAlpha);
         }
         if (singlePartOrInMulti)
-            m_presetNames[pt].setText(m_controller.getCurrentPartPresetName(pt),  juce::dontSendNotification);
+            m_presetNames[pt].setText(m_controller.getCurrentPartPresetName(pt),  dontSendNotification);
         else
-            m_presetNames[pt].setText("",  juce::dontSendNotification);
+            m_presetNames[pt].setText("",  dontSendNotification);
     }
 
     updatePlayModeButtons();
@@ -280,9 +280,9 @@ void ArpEditor::changePart(uint8_t _part)
 {
     for (auto &p : m_partSelect)
     {
-        p.setToggleState(false, juce::dontSendNotification);
+        p.setToggleState(false, dontSendNotification);
     }
-    m_partSelect[_part].setToggleState(true, juce::dontSendNotification);
+    m_partSelect[_part].setToggleState(true, dontSendNotification);
     m_parameterBinding.setPart(_part);
     getParentComponent()->postCommandMessage(VirusEditor::Commands::UpdateParts);
     getParentComponent()->postCommandMessage(VirusEditor::Commands::Rebind);
@@ -308,24 +308,24 @@ void ArpEditor::updatePlayModeButtons()
     const auto _mode = (int)modeParam->getValue();
     if (_mode == virusLib::PlayModeSingle)
     {
-        m_btWorkingMode.setToggleState(true, juce::dontSendNotification);
+        m_btWorkingMode.setToggleState(true, dontSendNotification);
     }
     else if (_mode == virusLib::PlayModeMulti || _mode == virusLib::PlayModeMultiSingle)
     {
-        m_btWorkingMode.setToggleState(false, juce::dontSendNotification);
+        m_btWorkingMode.setToggleState(false, dontSendNotification);
     }
 }
 
 void ArpEditor::updateMidiInput(int index)
 {
-    auto list = juce::MidiInput::getAvailableDevices();
+    auto list = MidiInput::getAvailableDevices();
 
     if (index == 0)
     {
         m_properties->setValue("midi_input", "");
         m_properties->save();
         m_lastInputIndex = index;
-        m_cmbMidiInput.setSelectedItemIndex(index, juce::dontSendNotification);
+        m_cmbMidiInput.setSelectedItemIndex(index, dontSendNotification);
         return;
     }
     index--;
@@ -336,7 +336,7 @@ void ArpEditor::updateMidiInput(int index)
 
     if (!processorRef.setMidiInput(newInput.identifier))
     {
-        m_cmbMidiInput.setSelectedItemIndex(0, juce::dontSendNotification);
+        m_cmbMidiInput.setSelectedItemIndex(0, dontSendNotification);
         m_lastInputIndex = 0;
         return;
     }
@@ -344,19 +344,19 @@ void ArpEditor::updateMidiInput(int index)
     m_properties->setValue("midi_input", newInput.identifier);
     m_properties->save();
 
-    m_cmbMidiInput.setSelectedItemIndex(index + 1, juce::dontSendNotification);
+    m_cmbMidiInput.setSelectedItemIndex(index + 1, dontSendNotification);
     m_lastInputIndex = index;
 }
 
 void ArpEditor::updateMidiOutput(int index)
 {
-    auto list = juce::MidiOutput::getAvailableDevices();
+    auto list = MidiOutput::getAvailableDevices();
 
     if (index == 0)
     {
         m_properties->setValue("midi_output", "");
         m_properties->save();
-        m_cmbMidiOutput.setSelectedItemIndex(index, juce::dontSendNotification);
+        m_cmbMidiOutput.setSelectedItemIndex(index, dontSendNotification);
         m_lastOutputIndex = index;
         processorRef.setMidiOutput("");
         return;
@@ -365,13 +365,13 @@ void ArpEditor::updateMidiOutput(int index)
     auto newOutput = list[index];
     if (!processorRef.setMidiOutput(newOutput.identifier))
     {
-        m_cmbMidiOutput.setSelectedItemIndex(0, juce::dontSendNotification);
+        m_cmbMidiOutput.setSelectedItemIndex(0, dontSendNotification);
         m_lastOutputIndex = 0;
         return;
     }
     m_properties->setValue("midi_output", newOutput.identifier);
     m_properties->save();
 
-    m_cmbMidiOutput.setSelectedItemIndex(index + 1, juce::dontSendNotification);
+    m_cmbMidiOutput.setSelectedItemIndex(index + 1, dontSendNotification);
     m_lastOutputIndex = index;
 }

--- a/source/jucePlugin/ui2/Virus_Panel5_PatchBrowser.cpp
+++ b/source/jucePlugin/ui2/Virus_Panel5_PatchBrowser.cpp
@@ -11,7 +11,7 @@ using namespace virusLib;
 
 float fBrowserScaleFactor = 2.0f;
 
-const juce::Array<juce::String> categories = {"", "Lead",	 "Bass",	  "Pad",	   "Decay",	   "Pluck",
+const Array<String> categories = {"", "Lead",	 "Bass",	  "Pad",	   "Decay",	   "Pluck",
                              "Acid", "Classic", "Arpeggiator", "Effects",	"Drums",	"Percussion",
                              "Input", "Vocoder", "Favourite 1", "Favourite 2", "Favourite 3"};
 
@@ -30,7 +30,7 @@ PatchBrowser::PatchBrowser(VirusParameterBinding & _parameterBinding, AudioPlugi
     //PatchBrowser
     m_bankList.setBounds(0, 185/fBrowserScaleFactor , 1030/fBrowserScaleFactor , 810/fBrowserScaleFactor );
     auto bankDir = m_properties->getValue("virus_bank_dir", "");
-    if (bankDir != "" && juce::File(bankDir).isDirectory())
+    if (bankDir != "" && File(bankDir).isDirectory())
     {
         m_bankList.setRoot(bankDir);
     }
@@ -60,7 +60,7 @@ PatchBrowser::PatchBrowser(VirusParameterBinding & _parameterBinding, AudioPlugi
     //Search
     m_search.setTransform(AffineTransform::scale(fBrowserScaleFactor));
     m_search.setSize(m_patchList.getWidth(), 20);
-    m_search.setColour(TextEditor::textColourId, juce::Colours::white);
+    m_search.setColour(TextEditor::textColourId, Colours::white);
 
     m_search.setTopLeftPosition(m_patchList.getBounds().getBottomLeft().translated(0, 8));
 
@@ -80,7 +80,7 @@ PatchBrowser::PatchBrowser(VirusParameterBinding & _parameterBinding, AudioPlugi
         m_patchList.deselectAllRows();
         m_patchList.repaint();
     };
-    m_search.setTextToShowWhenEmpty("search...", juce::Colours::grey);
+    m_search.setTextToShowWhenEmpty("search...", Colours::grey);
     addAndMakeVisible(m_search);
 
     //Show Options Buttons/Cmb
@@ -134,7 +134,7 @@ void PatchBrowser::IntiPatches()
     {
         m_bankList.setFileName(m_LastFileUsed);
         m_bankList.selectionChanged();
-        const juce::File &file(m_LastFileUsed);
+        const File &file(m_LastFileUsed);
         LoadPatchesFromFile(file);
     }
 }
@@ -148,17 +148,17 @@ void PatchBrowser::SaveSettings()
 }
 
 
-juce::String PatchBrowser::GetLastPatchSelected()
+String PatchBrowser::GetLastPatchSelected()
 {
     return m_LastPatchSelected;
 }
 
-juce::TableListBox* PatchBrowser::GetTablePatchList()
+TableListBox* PatchBrowser::GetTablePatchList()
 {
     return &m_patchList;
 }
 
-juce::String PatchBrowser::GetSelectBankNum()
+String PatchBrowser::GetSelectBankNum()
 {
     return getCurrentPartBankStr((virusLib::BankNumber)m_LastBankRomNoUsed);
 }
@@ -175,7 +175,7 @@ void PatchBrowser::selectionChanged() {}
 
 void PatchBrowser::LoadBankNr(int iBankNo) 
 {
-    juce::StringArray patches = m_controller.getSinglePresetNames((virusLib::BankNumber)(iBankNo));
+    StringArray patches = m_controller.getSinglePresetNames((virusLib::BankNumber)(iBankNo));
     m_patches.clear();
 
     for (int i=0 ; i<128 ; i++)
@@ -208,14 +208,14 @@ void PatchBrowser::LoadBankNr(int iBankNo)
 }
 
 
-int PatchBrowser::loadBankFile(const juce::File& file, const int _startIndex = 0, const bool dedupe = false) {
+int PatchBrowser::loadBankFile(const File& file, const int _startIndex = 0, const bool dedupe = false) {
     auto ext = file.getFileExtension().toLowerCase();
     auto path = file.getParentDirectory().getFullPathName();
     int loadedCount = 0;
     int index = _startIndex;
     if (ext == ".syx")
     {
-        juce::MemoryBlock data;
+        MemoryBlock data;
         if (!file.loadFileAsData(data)) {
             return 0;
         }
@@ -242,7 +242,7 @@ int PatchBrowser::loadBankFile(const juce::File& file, const int _startIndex = 0
                 else {
                     patch.model = guessVersion(patch.data);
                 }
-                auto md5 = juce::MD5(it+9 + 17, 256-17-3).toHexString();
+                auto md5 = MD5(it+9 + 17, 256-17-3).toHexString();
                 if(!dedupe || !m_checksums.contains(md5)) {
                     m_checksums.set(md5, true);
                     m_patches.add(patch);
@@ -253,7 +253,7 @@ int PatchBrowser::loadBankFile(const juce::File& file, const int _startIndex = 0
     }
     else if (ext == ".mid" || ext == ".midi")
     {
-        juce::MemoryBlock data;
+        MemoryBlock data;
         if (!file.loadFileAsData(data))
         {
             return 0;
@@ -290,7 +290,7 @@ int PatchBrowser::loadBankFile(const juce::File& file, const int _startIndex = 0
                     else {
                         patch.model = guessVersion(patch.data);
                     }
-                    auto md5 = juce::MD5(it+9 + 17, 256-17-3).toHexString();
+                    auto md5 = MD5(it+9 + 17, 256-17-3).toHexString();
                     if(!dedupe || !m_checksums.contains(md5)) {
                         m_checksums.set(md5, true);
                         m_patches.add(patch);
@@ -328,7 +328,7 @@ int PatchBrowser::loadBankFile(const juce::File& file, const int _startIndex = 0
                     else {
                         patch.model = guessVersion(patch.data);
                     }
-                    auto md5 = juce::MD5(it+2+9 + 17, 256-17-3).toHexString();
+                    auto md5 = MD5(it+2+9 + 17, 256-17-3).toHexString();
                     if(!dedupe || !m_checksums.contains(md5)) {
                         m_checksums.set(md5, true);
                         m_patches.add(patch);
@@ -344,19 +344,19 @@ int PatchBrowser::loadBankFile(const juce::File& file, const int _startIndex = 0
     return index;
 }
 
-void PatchBrowser::fileClicked(const juce::File &file, const juce::MouseEvent &e)
+void PatchBrowser::fileClicked(const File &file, const MouseEvent &e)
 {
     auto ext = file.getFileExtension().toLowerCase();
     auto path = file.getParentDirectory().getFullPathName();
 
     //Show popup only on directory
     if (file.isDirectory() && e.mods.isRightButtonDown()) {
-        auto p = juce::PopupMenu();
+        auto p = PopupMenu();
         p.addItem("Add directory contents to patch list", [this, file]() {
             m_patches.clear();
             m_checksums.clear();
             int lastIndex = 0;
-            for (auto f : juce::RangedDirectoryIterator(file, false, "*.syx;*.mid;*.midi", juce::File::findFiles)) {
+            for (auto f : RangedDirectoryIterator(file, false, "*.syx;*.mid;*.midi", File::findFiles)) {
                 lastIndex = loadBankFile(f.getFile(), lastIndex, true);
             }
             m_filteredPatches.clear();
@@ -373,7 +373,7 @@ void PatchBrowser::fileClicked(const juce::File &file, const juce::MouseEvent &e
             m_patchList.deselectAllRows();
             m_patchList.repaint();   
         });
-        p.showMenu(juce::PopupMenu::Options());
+        p.showMenu(PopupMenu::Options());
         
         return;
     }
@@ -392,7 +392,7 @@ void PatchBrowser::fileClicked(const juce::File &file, const juce::MouseEvent &e
     getParentComponent()->postCommandMessage(VirusEditor::Commands::UpdateParts);
 }
 
-void PatchBrowser::LoadPatchesFromFile(const juce::File &file)
+void PatchBrowser::LoadPatchesFromFile(const File &file)
 {
     m_patches.clear();
     loadBankFile(file);
@@ -412,7 +412,7 @@ void PatchBrowser::LoadPatchesFromFile(const juce::File &file)
 }
 
 
-void PatchBrowser::fileDoubleClicked(const juce::File &file) {}
+void PatchBrowser::fileDoubleClicked(const File &file) {}
 
 void PatchBrowser::browserRootChanged(const File &newRoot) {}
 
@@ -424,10 +424,10 @@ int PatchBrowser::getNumRows()
 void PatchBrowser::paintRowBackground(Graphics &g, int rowNumber, int width, int height, bool rowIsSelected) 
 {
     auto alternateColour = getLookAndFeel()
-                               .findColour(juce::ListBox::backgroundColourId)
-                               .interpolatedWith(getLookAndFeel().findColour(juce::ListBox::textColourId), 0.03f);
+                               .findColour(ListBox::backgroundColourId)
+                               .interpolatedWith(getLookAndFeel().findColour(ListBox::textColourId), 0.03f);
     if (rowIsSelected)
-        g.fillAll(juce::Colours::lightblue);
+        g.fillAll(Colours::lightblue);
     else if (rowNumber % 2)
         g.fillAll(alternateColour);
 }
@@ -435,17 +435,17 @@ void PatchBrowser::paintRowBackground(Graphics &g, int rowNumber, int width, int
 void PatchBrowser::paintCell(Graphics &g, int rowNumber, int columnId, int width, int height, bool rowIsSelected) 
 {
     //Banks from file
-    g.setColour(rowIsSelected ? juce::Colours::darkblue
-                            : getLookAndFeel().findColour(juce::ListBox::textColourId)); // [5]
+    g.setColour(rowIsSelected ? Colours::darkblue
+                            : getLookAndFeel().findColour(ListBox::textColourId)); // [5]
     
     auto rowElement = m_filteredPatches[rowNumber];
     //auto text = rowElement.name;
-    juce::String text = "";
+    String text = "";
 
     if (m_bIsFileMode)
     {
         if (columnId == ColumnsPatch::INDEX)
-            text = juce::String(rowElement.progNumber+1);
+            text = String(rowElement.progNumber+1);
         else if (columnId == ColumnsPatch::NAME)
             text = rowElement.name;
         else if (columnId == ColumnsPatch::CAT1)
@@ -455,9 +455,9 @@ void PatchBrowser::paintCell(Graphics &g, int rowNumber, int columnId, int width
         else if (columnId == ColumnsPatch::ARP)
             text = rowElement.data[129] != 0 ? "Y" : " ";
         else if(columnId == ColumnsPatch::UNI)
-            text = rowElement.unison == 0 ? " " : juce::String(rowElement.unison+1);
+            text = rowElement.unison == 0 ? " " : String(rowElement.unison+1);
         else if(columnId == ColumnsPatch::ST)
-            text = rowElement.transpose != 64 ? juce::String(rowElement.transpose - 64) : " ";
+            text = rowElement.transpose != 64 ? String(rowElement.transpose - 64) : " ";
         else if (columnId == ColumnsPatch::VER) {
             if(rowElement.model < ModelList.size())
                 text = ModelList[rowElement.model];
@@ -466,13 +466,13 @@ void PatchBrowser::paintCell(Graphics &g, int rowNumber, int columnId, int width
 	else
 	{
         if (columnId == ColumnsPatch::INDEX)
-            text = juce::String(rowElement.progNumber+1);
+            text = String(rowElement.progNumber+1);
         else if (columnId == ColumnsPatch::NAME)
             text = rowElement.name;
     }
 
-    g.drawText(text, 2, 0, width - 4, height, juce::Justification::centredLeft, true); // [6]
-    g.setColour(getLookAndFeel().findColour(juce::ListBox::backgroundColourId));
+    g.drawText(text, 2, 0, width - 4, height, Justification::centredLeft, true); // [6]
+    g.setColour(getLookAndFeel().findColour(ListBox::backgroundColourId));
     g.fillRect(width - 1, 0, 1, height); // [7]
 
 }
@@ -484,7 +484,7 @@ void PatchBrowser::selectedRowsChanged(int lastRowSelected) {
         return;
     }
     
-    juce::Component *c;
+    Component *c;
     c = m_patchList.getCellComponent(1,idx);
 
     if (m_bIsFileMode)
@@ -524,7 +524,7 @@ void PatchBrowser::selectedRowsChanged(int lastRowSelected) {
     }
 }
 
-void PatchBrowser::cellDoubleClicked(int rowNumber, int columnId, const juce::MouseEvent &)
+void PatchBrowser::cellDoubleClicked(int rowNumber, int columnId, const MouseEvent &)
 {
    /* if(m_modeIndex==1)
     {
@@ -549,12 +549,12 @@ void PatchBrowser::sortOrderChanged(int newSortColumnId, bool isForwards)
 }
 
 
-void PatchBrowser::loadBankFileToRom(const juce::File &file)
+void PatchBrowser::loadBankFileToRom(const File &file)
 {   
     bool sentData = false;
     auto sExt = file.getFileExtension().toLowerCase();
     m_previousPath = file.getParentDirectory().getFullPathName();;
-    juce::MemoryBlock data;
+    MemoryBlock data;
 
     if (sExt == ".syx")
     {
@@ -632,11 +632,11 @@ void PatchBrowser::loadBankFileToRom(const juce::File &file)
 
 void PatchBrowser::loadFile()
 {
-    juce::MemoryBlock data;
-    juce::FileChooser chooser(
+    MemoryBlock data;
+    FileChooser chooser(
         "Choose syx/midi banks to import",
         m_previousPath.isEmpty()
-            ? juce::File::getSpecialLocation(juce::File::currentApplicationFile).getParentDirectory()
+            ? File::getSpecialLocation(File::currentApplicationFile).getParentDirectory()
             : m_previousPath,
         "*.syx,*.mid,*.midi", true);
 
@@ -647,10 +647,10 @@ void PatchBrowser::loadFile()
 }
 
 void PatchBrowser::savePreset() {
-    juce::FileChooser chooser(
+    FileChooser chooser(
         "Save preset as syx",
         m_previousPath.isEmpty()
-            ? juce::File::getSpecialLocation(juce::File::currentApplicationFile).getParentDirectory()
+            ? File::getSpecialLocation(File::currentApplicationFile).getParentDirectory()
             : m_previousPath,
         "*.syx", true);
 


### PR DESCRIPTION
Why
----
* synchronized methods are now being a #DEFINE in JUCE for a reason (as some platforms aren't supporting such workflows)

* tidy - it's cleaner and should be the one way or another. using namespace... **do not** use namespace in each object. or... remove using namespace and explicitly call each object with the namespace.

The first imho is more coherent since the context is within editor which is in "juce" land.