### PR TITLE
Fix "Deleted selected" typo in patch browser context menu

### DIFF
--- a/source/jucePluginEditorLib/patchmanager/grouptreeitem.cpp
+++ b/source/jucePluginEditorLib/patchmanager/grouptreeitem.cpp
@@ -134,7 +134,7 @@ namespace jucePluginEditorLib::patchManager
 
 		if(m_type == GroupType::DataSources)
 		{
-			menu.addItem("Add Folders...", [this]
+			menu.addItem("Add folders...", [this]
 			{
 				juce::FileChooser fc("Select Folders");
 
@@ -156,7 +156,7 @@ namespace jucePluginEditorLib::patchManager
 				}
 			});
 
-			menu.addItem("Add Files...", [this]
+			menu.addItem("Add files...", [this]
 			{
 				juce::FileChooser fc("Select Files");
 				if(fc.showDialog(

--- a/source/jucePluginEditorLib/patchmanager/list.cpp
+++ b/source/jucePluginEditorLib/patchmanager/list.cpp
@@ -194,7 +194,7 @@ namespace jucePluginEditorLib::patchManager
 			}
 			else if(getSourceType() == pluginLib::patchDB::SourceType::LocalStorage)
 			{
-				menu.addItem("Deleted selected", [this, s = selectedPatches]
+				menu.addItem("Delete selected", [this, s = selectedPatches]
 				{
 					if(showDeleteConfirmationMessageBox())
 					{
@@ -290,11 +290,11 @@ namespace jucePluginEditorLib::patchManager
 			}
 		}
 		menu.addSeparator();
-		menu.addItem("Hide Duplicates (by hash)", true, m_hideDuplicatesByHash, [this]
+		menu.addItem("Hide duplicates (by hash)", true, m_hideDuplicatesByHash, [this]
 		{
 			setFilter(m_filter, !m_hideDuplicatesByHash, m_hideDuplicatesByName);
 		});
-		menu.addItem("Hide Duplicates (by name)", true, m_hideDuplicatesByName, [this]
+		menu.addItem("Hide duplicates (by name)", true, m_hideDuplicatesByName, [this]
 		{
 			setFilter(m_filter, m_hideDuplicatesByHash, !m_hideDuplicatesByName);
 		});


### PR DESCRIPTION
Also make letter case consistent for other context menu entries in the patch browser