### PR TITLE
Improve column breaks for dropdown menu based parameters

### DIFF
--- a/source/jucePluginLib/parameterbinding.cpp
+++ b/source/jucePluginLib/parameterbinding.cpp
@@ -133,10 +133,15 @@ namespace pluginLib
 	
 		uint32_t count = 0;
 
-		for (const auto& vs : sortedValues)
+		// we want our long menus to be split into columns of 16 rows each
+		// but only if we have have more entries than one and a half such column
+		const uint32_t splitAt = (sortedValues.size() > 24) ? 16 : 0;
+
+		for (const auto &vs : sortedValues)
 		{
 			_combo.addItem(vs.second, vs.first + 1);
-			if(++count == 16)
+
+			if (++count == splitAt)
 			{
 				_combo.getRootMenu()->addColumnBreak();
 				count = 0;


### PR DESCRIPTION
Previously column breaks happened after every 16th menu entry verbatim, no chance of parole. With this change a column break will only happen if we have more than one and a half columns of entries total (16 + 8).

This allows changing menus like part MIDI channel in Xenia from looking like this:

![image](https://github.com/dsp56300/gearmulator/assets/2393720/175b0526-8120-422d-9ab9-2f73a1010539)

into looking like this:

![image](https://github.com/dsp56300/gearmulator/assets/2393720/87be527a-41b0-4247-9a97-2da8b4472ce8)

which is far more visually agreeable, I think 🙂 