### PR TITLE
Add "displayTime" property to the tooltip component in the skin engine

### DIFF
--- a/source/jucePluginEditorLib/focusedParameter.cpp
+++ b/source/jucePluginEditorLib/focusedParameter.cpp
@@ -47,7 +47,7 @@ namespace jucePluginEditorLib
 	FocusedParameter::~FocusedParameter()
 	{
 		m_tooltip.reset();
-
+	
 		for (auto* p : m_boundParameters)
 			p->removeListener(g_listenerId);
 	}
@@ -140,6 +140,8 @@ namespace jucePluginEditorLib
 
 		m_tooltip->initialize(_component, value);
 
-		startTimer(3000);
+		const int tooltipTime = m_tooltip->getTooltipDisplayTime();
+
+		startTimer(tooltipTime == 0 ? 1500 : tooltipTime);
 	}
 }

--- a/source/jucePluginEditorLib/focusedParameterTooltip.cpp
+++ b/source/jucePluginEditorLib/focusedParameterTooltip.cpp
@@ -14,13 +14,23 @@ namespace jucePluginEditorLib
 
 	void FocusedParameterTooltip::setVisible(bool _visible) const
 	{
-		if (isValid())
+		if(isValid())
 			m_label->setVisible(_visible);
+	}
+
+	int FocusedParameterTooltip::getTooltipDisplayTime() const
+	{
+		int time = 0;
+
+		if(m_label->getProperties().contains("displayTime"))
+			time = static_cast<int>(m_label->getProperties()["displayTime"]);
+
+		return time;
 	}
 
 	void FocusedParameterTooltip::initialize(juce::Component* _component, const juce::String& _value) const
 	{
-		if (!isValid())
+		if(!isValid())
 			return;
 
 		if(dynamic_cast<juce::Slider*>(_component) && _component->isShowing())

--- a/source/jucePluginEditorLib/focusedParameterTooltip.h
+++ b/source/jucePluginEditorLib/focusedParameterTooltip.h
@@ -15,6 +15,7 @@ namespace jucePluginEditorLib
 		FocusedParameterTooltip(juce::Label* _label);
 
 		bool isValid() const { return m_label != nullptr; }
+		int getTooltipDisplayTime() const;
 		void setVisible(bool _visible) const;
 		void initialize(juce::Component* _component, const juce::String& _value) const;
 

--- a/source/xtJucePlugin/skins/xtDefault/xtDefault.json
+++ b/source/xtJucePlugin/skins/xtDefault/xtDefault.json
@@ -8879,6 +8879,7 @@
                 "height" : "55"
             },
             "componentProperties" : {
+                "displayTime" : "2000",
                 "offsetY" : "25"
             }
         }


### PR DESCRIPTION
Also reduce the default tooltip time to 2 seconds. I prefer it even shorter (500 ms) but now I can set it up for myself. 🙂 3 seconds definitely felt too long IMO!