### PR TITLE
fix: add missing header (cstdint)

### DIFF
--- a/source/nord/n2x/n2xJucePlugin/n2xMasterVolume.h
+++ b/source/nord/n2x/n2xJucePlugin/n2xMasterVolume.h
@@ -2,6 +2,8 @@
 
 #include "jucePluginLib/event.h"
 
+#include <cstdint>
+
 namespace n2x
 {
 	enum class KnobType;

--- a/source/nord/n2x/n2xJucePlugin/n2xParameterDrivenLed.h
+++ b/source/nord/n2x/n2xJucePlugin/n2xParameterDrivenLed.h
@@ -3,6 +3,7 @@
 #include "jucePluginLib/parameterlistener.h"
 
 #include <string>
+#include <cstdint>
 
 namespace juce
 {


### PR DESCRIPTION
Fails to build on Linux using gcc as compiler, the following error messages appear upon compilation:

```
In file included from /gearmulator/source/nord/n2x/n2xJucePlugin/n2xArp.h:3,
                 from /gearmulator/source/nord/n2x/n2xJucePlugin/n2xArp.cpp:1:
/gearmulator/source/nord/n2x/n2xJucePlugin/n2xParameterDrivenLed.h:19:34: error: ‘uint8_t’ does not name a type
   19 |                 static constexpr uint8_t CurrentPart = 0xff;
      |                                  ^~~~~~~
/gearmulator/source/nord/n2x/n2xJucePlugin/n2xParameterDrivenLed.h:6:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’                                      5 | #include <string>
  +++ |+#include <cstdint>
    6 |
/gearmulator/source/nord/n2x/n2xJucePlugin/n2xParameterDrivenLed.h:21:117: error: ‘uint8_t’ has not been declared
   21 |                 explicit ParameterDrivenLed(Editor& _editor, const std::string& _component, std::string _parameter, uint8_t _part = CurrentPart);
      |                                                                                                                     ^~~~~~~
/gearmulator/source/nord/n2x/n2xJucePlugin/n2xParameterDrivenLed.h:38:23: error: ‘uint8_t’ does not name a type
   38 |                 const uint8_t m_part;
      |                       ^~~~~~~
/gearmulator/source/nord/n2x/n2xJucePlugin/n2xParameterDrivenLed.h:38:23: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/gearmulator/source/nord/n2x/n2xJucePlugin/n2xParameterDrivenLed.h:41:42: error: ‘uint8_t’ was not declared in this scope                                                                                             41 |                 pluginLib::EventListener<uint8_t> m_onCurrentPartChanged;
      |                                          ^~~~~~~
/gearmulator/source/nord/n2x/n2xJucePlugin/n2xParameterDrivenLed.h:41:42: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/gearmulator/source/nord/n2x/n2xJucePlugin/n2xParameterDrivenLed.h:41:49: error: template argument 1 is invalid
   41 |                 pluginLib::EventListener<uint8_t> m_onCurrentPartChanged;                                                                                                                                        |                                                 ^
/gearmulator/source/nord/n2x/n2xJucePlugin/n2xParameterDrivenLed.h:21:133: error: ‘CurrentPart’ was not declared in this scope
   21 |                 explicit ParameterDrivenLed(Editor& _editor, const std::string& _component, std::string _parameter, uint8_t _part = CurrentPart);
      |                                                                                                                                     ^~~~~~~~~~~

In file included from /gearmulator/source/nord/n2x/n2xJucePlugin/n2xMasterVolume.cpp:1: /gearmulator/source/nord/n2x/n2xJucePlugin/n2xMasterVolume.h:29:57: error: ‘uint8_t’ was not declared in this scope
   29 |                 pluginLib::EventListener<n2x::KnobType, uint8_t> m_onKnobChanged;
      |                                                         ^~~~~~~
/gearmulator/source/nord/n2x/n2xJucePlugin/n2xMasterVolume.h:4:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
    3 | #include "jucePluginLib/event.h"
  +++ |+#include <cstdint>
    4 |
/gearmulator/source/nord/n2x/n2xJucePlugin/n2xMasterVolume.h:29:64: error: template argument 2 is invalid
   29 |                 pluginLib::EventListener<n2x::KnobType, uint8_t> m_onKnobChanged;
      |                                                                ^
/gearmulator/source/nord/n2x/n2xJucePlugin/n2xMasterVolume.cpp: In constructor ‘n2xJucePlugin::MasterVolume::MasterVolume(const n2xJucePlugin::Editor&)’:
/gearmulator/source/nord/n2x/n2xJucePlugin/n2xMasterVolume.cpp:26:33: error: request for member ‘set’ in ‘((n2xJucePlugin::MasterVolume*)this)->n2xJucePlugin::MasterVolume::m_onKnobChanged’, which is of non-class type ‘int’
   26 |                 m_onKnobChanged.set(_editor.getN2xController().onKnobChanged, [this](const n2x::KnobType& _type, const unsigned char& _value)
      |                                 ^~~
```