### PR TITLE
Cleaner looking skin submenu

### DIFF
--- a/source/jucePluginEditorLib/pluginEditorState.cpp
+++ b/source/jucePluginEditorLib/pluginEditorState.cpp
@@ -201,7 +201,7 @@ void PluginEditorState::openMenu(const juce::MouseEvent* _event)
 				const auto pathEndPos = jsonName.find_last_of("/\\");
 				if(pathEndPos != std::string::npos)
 					jsonName = file.substr(pathEndPos+1);
-				const Skin skin{jsonName + " (" + relativePath + ")", jsonName, relativePath};
+				const Skin skin{jsonName.substr(0, jsonName.length() - 5), jsonName, relativePath};
 				addSkinEntry(skin);
 			}
 		}
@@ -389,7 +389,7 @@ void PluginEditorState::openMenu(const juce::MouseEvent* _event)
 		{
 			if(!allowAdvanced)
 			{
-				if(juce::NativeMessageBox::showOkCancelBox(juce::AlertWindow::WarningIcon, "Warning", 
+				if(juce::NativeMessageBox::showOkCancelBox(juce::AlertWindow::WarningIcon, "Warning",
 					"Changing these settings may cause instability of the plugin.\n"
 					"\n"
 					"Please confirm to continue.")


### PR DESCRIPTION
The user doesn't really need to know the file extension, and I would say that the relative path to skin is also not really important. It would probably be better to add an option to reveal the currently selected skin in Explorer/Finder instead (in a separate PR).

![image](https://github.com/user-attachments/assets/171b58e9-7346-47e0-9159-de666b6ac78a)
