### PR TITLE
Better folder locations for settings on Linux

### DIFF
--- a/source/mqJucePlugin/PluginProcessor.cpp
+++ b/source/mqJucePlugin/PluginProcessor.cpp
@@ -13,10 +13,14 @@ namespace
 	juce::PropertiesFile::Options getOptions()
 	{
 		juce::PropertiesFile::Options opts;
-		opts.applicationName = "DSP56300EmulatorVavra";
-		opts.filenameSuffix = ".settings";
-		opts.folderName = "DSP56300EmulatorVavra";
-		opts.osxLibrarySubFolder = "Application Support/DSP56300EmulatorVavra";
+		opts.applicationName = "vavra";
+		opts.filenameSuffix = "settings";
+#ifdef JUCE_LINUX 
+  	opts.folderName = ".config/The Usual Suspects/Vavra";
+#else
+  	opts.folderName = "The Usual Suspects/Vavra";
+#endif
+		opts.osxLibrarySubFolder = "Application Support";
 		return opts;
 	}
 

--- a/source/nord/n2x/n2xJucePlugin/n2xPluginProcessor.cpp
+++ b/source/nord/n2x/n2xJucePlugin/n2xPluginProcessor.cpp
@@ -16,10 +16,14 @@ namespace
 	juce::PropertiesFile::Options getOptions()
 	{
 		juce::PropertiesFile::Options opts;
-		opts.applicationName = "DSP56300EmulatorNodalRed";
-		opts.filenameSuffix = ".settings";
-		opts.folderName = "DSP56300EmulatorNodalRed";
-		opts.osxLibrarySubFolder = "Application Support/DSP56300EmulatorNodalRed";
+		opts.applicationName = "n2x";
+		opts.filenameSuffix = "settings";
+#ifdef JUCE_LINUX 
+  	opts.folderName = ".config/The Usual Suspects/NodalRed2x";
+#else
+  	opts.folderName = "The Usual Suspects/NodalRed2x";
+#endif
+		opts.osxLibrarySubFolder = "Application Support";
 		return opts;
 	}
 

--- a/source/osTIrusJucePlugin/OsTIrusProcessor.cpp
+++ b/source/osTIrusJucePlugin/OsTIrusProcessor.cpp
@@ -9,10 +9,14 @@ namespace
 	juce::PropertiesFile::Options getConfigOptions()
 	{
 		juce::PropertiesFile::Options opts;
-		opts.applicationName = "DSP56300Emulator_OsTIrus";
-		opts.filenameSuffix = ".settings";
-		opts.folderName = "DSP56300Emulator_OsTIrus";
-		opts.osxLibrarySubFolder = "Application Support/DSP56300Emulator_OsTIrus";
+		opts.applicationName = "ostirus";
+		opts.filenameSuffix = "settings";
+#ifdef JUCE_LINUX 
+  	opts.folderName = ".config/The Usual Suspects/OsTIrus";
+#else
+  	opts.folderName = "The Usual Suspects/OsTIrus";
+#endif
+		opts.osxLibrarySubFolder = "Application Support";
 		return opts;
 	}
 

--- a/source/osirusJucePlugin/OsirusProcessor.cpp
+++ b/source/osirusJucePlugin/OsirusProcessor.cpp
@@ -9,10 +9,14 @@ namespace
 	juce::PropertiesFile::Options getConfigOptions()
 	{
 		juce::PropertiesFile::Options opts;
-		opts.applicationName = "DSP56300 Emulator";
-		opts.filenameSuffix = ".settings";
-		opts.folderName = "DSP56300 Emulator";
-		opts.osxLibrarySubFolder = "Application Support/DSP56300 Emulator";
+		opts.applicationName = "osirus";
+		opts.filenameSuffix = "settings";
+#ifdef JUCE_LINUX 
+  	opts.folderName = ".config/The Usual Suspects/Osirus";
+#else
+  	opts.folderName = "The Usual Suspects/Osirus";
+#endif
+		opts.osxLibrarySubFolder = "Application Support";
 		return opts;
 	}
 

--- a/source/xtJucePlugin/PluginProcessor.cpp
+++ b/source/xtJucePlugin/PluginProcessor.cpp
@@ -15,10 +15,14 @@ namespace
 	juce::PropertiesFile::Options getOptions()
 	{
 		juce::PropertiesFile::Options opts;
-		opts.applicationName = "DSP56300EmulatorXenia";
-		opts.filenameSuffix = ".settings";
-		opts.folderName = "DSP56300EmulatorXenia";
-		opts.osxLibrarySubFolder = "Application Support/DSP56300EmulatorXenia";
+		opts.applicationName = "xenia";
+		opts.filenameSuffix = "settings";
+#ifdef JUCE_LINUX 
+  	opts.folderName = ".config/The Usual Suspects/Xenia";
+#else
+  	opts.folderName = "The Usual Suspects/Xenia";
+#endif
+		opts.osxLibrarySubFolder = "Application Support";
 		return opts;
 	}
 


### PR DESCRIPTION
- They used to clutter the home folder. Moving to ~/.config/The Usual Suspects/*
- In line with the folder locations for roms and skins that are in ~/.local/share/The Usual Suspects/*