### PR TITLE
Fix LV2 URI so parameter symbols can be correctly parsed by lilv library.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -62,8 +62,8 @@
         "gearmulator_SYNTH_NODALRED2X": "OFF",
         "gearmulator_SYNTH_OSIRUS": "ON",
         "gearmulator_SYNTH_OSTIRUS": "ON",
-        "gearmulator_SYNTH_VAVRA": "OFF",
-        "gearmulator_SYNTH_XENIA": "OFF"
+        "gearmulator_SYNTH_VAVRA": "ON",
+        "gearmulator_SYNTH_XENIA": "ON"
       }
     },
     {

--- a/source/juce.cmake
+++ b/source/juce.cmake
@@ -130,7 +130,7 @@ macro(createJucePlugin targetName productName isSynth plugin4CC binaryDataProjec
 		VST3_AUTO_MANIFEST TRUE                           # While generating a moduleinfo.json is nice, Juce does not properly package using cpack on Win/Linux
 		                                                  # and completely fails on Linux if we change the suffix to .vst3, so we skip that completely for now
 		BUNDLE_ID "com.theusualsuspects.${productName}"
-		LV2URI "http://theusualsuspects.lv2.${productName}"
+		LV2URI "http://theusualsuspects.lv2/${productName}"
 	)
 
 	target_sources(${targetName} PRIVATE ${SOURCES} serverPlugin.cpp)


### PR DESCRIPTION
Enable build for Vavra and Xenia in zynthian CMake preset.