### PR TITLE
Sync patchmanager UI selection with host-driven setStateInformation

### DIFF
--- a/source/jucePluginEditorLib/patchmanager/patchmanager.cpp
+++ b/source/jucePluginEditorLib/patchmanager/patchmanager.cpp
@@ -71,6 +71,22 @@ namespace jucePluginEditorLib::patchManager
 			});
 
 		setUi(std::make_unique<patchManagerRml::PatchManagerUiRml>(m_editor, *this, *m_editor.getRmlComponent(), _rootElement, *m_editor.getPatchManagerDataModel(), _groupTypes));
+
+		// Subscribe to host-driven state loads. Defer the work onto the JUCE
+		// message thread because evStateLoaded may fire from the audio thread
+		// (or any host thread that drove setStateInformation), and the patch
+		// search + UI update must run on the message thread.
+		m_onStateLoaded.set(_editor.getProcessor().evStateLoaded, [this]
+		{
+			auto* self = this;
+			juce::MessageManager::callAsync([self]
+			{
+				std::lock_guard lock(getInstancesMutex());
+				if (getInstances().find(self) == getInstances().end())
+					return;
+				self->selectActivePatch(self->getCurrentPart());
+			});
+		});
 	}
 
 	PatchManager::~PatchManager()
@@ -618,6 +634,40 @@ namespace jucePluginEditorLib::patchManager
 			return;
 
 		setSelectedPatch(_part, m_state.getPatch(_part));
+	}
+
+	void PatchManager::selectActivePatch(const uint32_t _part)
+	{
+		// Ask the controller for whatever the audio engine is currently
+		// playing on _part. The convenience overload returns a fully-built
+		// PatchPtr with content hash (MD5) computed by the per-plugin
+		// initializePatch() implementation.
+		const auto active = requestPatchForPart(_part);
+		if (!active)
+			return;
+
+		// Linear scan of every loaded data source, matching by content hash.
+		// Patches imported from different sources but identical bytes will
+		// share a hash, so we stop at the first match.
+		std::vector<pluginLib::patchDB::DataSourceNodePtr> sources;
+		getDataSources(sources);
+		for (const auto& ds : sources)
+		{
+			if (!ds)
+				continue;
+			for (const auto& p : ds->patches)
+			{
+				if (p && p->hash == active->hash)
+				{
+					setSelectedPatch(_part, p);
+					return;
+				}
+			}
+		}
+		// No matching patch in any loaded source. Leave selection as-is —
+		// clearing it would surprise users who manually loaded a one-off
+		// patch via SysEx import; better to do nothing than make the UI
+		// look like a search lost the user's place.
 	}
 
 	void PatchManager::updateStateAsync(const uint32_t _part, const pluginLib::patchDB::PatchPtr& _patch)

--- a/source/jucePluginEditorLib/patchmanager/patchmanager.h
+++ b/source/jucePluginEditorLib/patchmanager/patchmanager.h
@@ -116,6 +116,13 @@ namespace jucePluginEditorLib::patchManager
 
 		void setCurrentPart(uint32_t _part);
 
+		// Hash the patch the plugin is currently playing on _part and update
+		// the UI selection to match if a corresponding entry exists in any
+		// loaded data source. Used by the evStateLoaded subscription so a
+		// host-driven state load (NKS preset load in Komplete Kontrol etc.)
+		// reflects in the patchmanager browser, not just the audio engine.
+		void selectActivePatch(uint32_t _part);
+
 	protected:
 		void updateStateAsync(uint32_t _part, const pluginLib::patchDB::PatchPtr& _patch);
 
@@ -133,5 +140,10 @@ namespace jucePluginEditorLib::patchManager
 
 		Editor& m_editor;
 		std::unique_ptr<PatchManagerUi> m_ui;
+
+		// Subscribed to Processor::evStateLoaded — fires after a host-driven
+		// setState restores the audio engine, so the UI selection can be
+		// brought in line with what's actually playing.
+		baseLib::EventListener<> m_onStateLoaded;
 	};
 }

--- a/source/jucePluginLib/processor.cpp
+++ b/source/jucePluginLib/processor.cpp
@@ -936,6 +936,14 @@ namespace pluginLib
 
 		if (hasController())
 			getController().onStateLoaded();
+
+		// Notify subscribers (PatchManager, etc.) that the audio state was
+		// restored from the host. Lets the UI refresh selection state to match
+		// what the host just loaded — without this, a host-driven state load
+		// (e.g. NKS preset load in Komplete Kontrol) leaves the patchmanager
+		// UI showing stale or no selection while the audio engine plays the
+		// new patch.
+		evStateLoaded();
 	}
 #endif
 
@@ -1010,6 +1018,9 @@ namespace pluginLib
 		juce::MessageManager::callAsync([this]
 		{
 			getController().onStateLoaded();
+			// Same notification as the synchronous setState path — keeps the
+			// patchmanager UI in sync with what the audio engine is playing.
+			evStateLoaded();
 		});
 
 		return m_device.get();

--- a/source/jucePluginLib/processor.h
+++ b/source/jucePluginLib/processor.h
@@ -12,6 +12,8 @@
 
 #include "bridgeLib/types.h"
 
+#include "baseLib/event.h"
+
 #include "synthLib/midiRoutingMatrix.h"
 #include "synthLib/plugin.h"
 
@@ -77,6 +79,15 @@ namespace pluginLib
 		synthLib::Plugin& getPlugin();
 
 		ProgramChangeRouter& getProgramChangeRouter() { return m_programChangeRouter; }
+
+		// Fires after Processor::setState has restored the plugin's audio state
+		// (called once for both StateTypeGlobal and StateTypeCurrentProgram via
+		// setStateInformation / setCurrentProgramStateInformation paths).
+		// PatchManager subscribes to refresh the UI's currently-selected patch
+		// so a host-driven state load (e.g. NKS preset load in Komplete Kontrol)
+		// is reflected in the patchmanager browser, matching what a manual
+		// click would do.
+		baseLib::Event<> evStateLoaded;
 
 		virtual synthLib::Device* createDevice() = 0;
 		virtual bridgeClient::RemoteDevice* createRemoteDevice(const synthLib::DeviceCreateParams& _params);


### PR DESCRIPTION
## Summary

When a VST3 host (e.g. Native Instruments Komplete Kontrol loading an NKS preset) calls `setStateInformation`, the audio engine correctly restores the new patch via `Plugin::setState`, but the patchmanager UI keeps showing whatever was previously selected (or nothing). The selection state is set only from manual UI clicks via `setSelectedPatch`, never from the state-restore path.

This PR fixes that with a small generic mechanism that benefits every gearmulator-based plugin (Microwave XT, Virus, microQ, JD-800, Nord Lead 2X) without per-plugin code changes.

## Implementation

- New parameterless event `Processor::evStateLoaded` (jucePluginLib).
- Fired at the end of `Processor::setState`, on both the synchronous and async device-recreate paths.
- `PatchManager` subscribes in its constructor and, on the message thread, hashes whatever the audio engine is currently playing on the active part (via the existing `requestPatchForPart` convenience overload, which already computes the per-plugin MD5 hash) and then linear-scans loaded data sources for a matching content hash.
- A match drives `setSelectedPatch`. No match leaves selection unchanged (clearing it would surprise users who manually loaded one-off SysEx imports).

The hash-lookup approach means no per-plugin code change is required — each subclass already implements `requestPatchForPart` and `initializePatch` which together provide the canonical hash for the active patch.

## How was this discovered

While building Automated Preview Creator (APC), a tool that generates NKS preview files for VST3 plugins so musicians can browse and load presets directly from NI hardware. APC's generated NKS files correctly cause the audio engine to play the right patch (verified with both setstate-getstate round-trip and live audio rendering), but the plugin's patchmanager UI stayed empty after KK loaded the preset. Investigation traced this to `setSelectedPatch` only being reachable from UI click paths, never from `setStateInformation`.

## Test plan

- Build with each plugin variant (XT, Virus, microQ, JD-800, NL2X).
- Manual: load a known-cached patch via NKS / external host setStateInformation; patchmanager UI should highlight the matching entry.
- Manual: load a foreign SysEx (no match in cache); patchmanager UI selection should remain unchanged (no false clear).
- Manual: ensure manual-click selection still works as before (regression check).
- Verify no thread issues — the listener defers to the JUCE message thread via `juce::MessageManager::callAsync` and re-checks the instance is still alive (same pattern used by the existing program-change router subscription).
