### PR TITLE
Feature: panic skin buttons

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "source/3rdparty/freetype"]
 	path = source/3rdparty/freetype
 	url = https://github.com/freetype/freetype.git
+[submodule "source/3rdparty/lunasvg"]
+	path = source/3rdparty/lunasvg
+	url = https://github.com/sammycage/lunasvg.git

--- a/build_mac.sh
+++ b/build_mac.sh
@@ -1,4 +1,5 @@
-cmake -G Xcode -S . -B ./temp/cmake
-cd ./temp/cmake
-cmake --build . --config Release
-cpack -G ZIP
+cmake -G Xcode -S . -B ./temp/cmake_macos
+cmake --build ./temp/cmake_macos --config Release
+cd ./temp/cmake_macos
+CMAKE_BIN="$(dirname "$(command -v cmake)")"
+"${CMAKE_BIN}/cpack" -G ZIP

--- a/source/3rdparty/CMakeLists.txt
+++ b/source/3rdparty/CMakeLists.txt
@@ -18,9 +18,14 @@ add_library(Freetype::Freetype ALIAS freetype)
 # Lua 5.4 for RmlUi scripting
 add_subdirectory(lua)
 
+# lunasvg for RmlUi SVG plugin
+set(LUNASVG_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+add_subdirectory(lunasvg)
+
 # Enable RmlUi Lua bindings and point to our bundled Lua
 set(RMLUI_LUA_BINDINGS ON CACHE BOOL "" FORCE)
 set(RMLUI_LUA_BINDINGS_LIBRARY "lua_as_cxx" CACHE STRING "" FORCE)
+set(RMLUI_SVG_PLUGIN ON CACHE BOOL "" FORCE)
 
 # Create the Lua::Lua target so RmlUi's Dependencies.cmake finds it and skips find_package(Lua)
 add_library(Lua::Lua INTERFACE IMPORTED)

--- a/source/jucePluginEditorLib/settingsMidi.cpp
+++ b/source/jucePluginEditorLib/settingsMidi.cpp
@@ -87,28 +87,17 @@ namespace jucePluginEditorLib
 
 	void SettingsMidi::panicSendAllNotesOff() const
 	{
-		for(uint8_t c=0; c<16; ++c)
-		{
-			synthLib::SMidiEvent ev(synthLib::MidiEventSource::Editor, synthLib::M_CONTROLCHANGE + c, synthLib::MC_ALLNOTESOFF);
-			m_processor.addMidiEvent(ev);
-		}
+		m_processor.panicAllNotesOff();
 	}
 
 	void SettingsMidi::panicSendNoteOffForEveryNote() const
 	{
-		for(uint8_t c=0; c<16; ++c)
-		{
-			for(uint8_t n=0; n<128; ++n)
-			{
-				synthLib::SMidiEvent ev(synthLib::MidiEventSource::Editor, synthLib::M_NOTEOFF + c, n, 64, n * 256);
-				m_processor.addMidiEvent(ev);
-			}
-		}
+		m_processor.panicNoteOffEveryNote();
 	}
 
 	void SettingsMidi::panicRebootDevice() const
 	{
-		m_processor.rebootDevice();
+		m_processor.panicRebootDevice();
 	}
 
 	void SettingsMidi::createMatrix(Rml::Element* _root, synthLib::MidiRoutingMatrix::EventType _type, const char* _name)

--- a/source/jucePluginLib/processor.cpp
+++ b/source/jucePluginLib/processor.cpp
@@ -16,6 +16,7 @@
 #include "client/remoteDevice.h"
 
 #include "synthLib/deviceException.h"
+#include "synthLib/midiTypes.h"
 #include "synthLib/os.h"
 #include "synthLib/midiBufferParser.h"
 #include "synthLib/romLoader.h"
@@ -61,6 +62,32 @@ namespace pluginLib
 		destroyController();
 		m_plugin.reset();
 		m_device.reset();
+	}
+
+	void Processor::panicAllNotesOff()
+	{
+		for(uint8_t c = 0; c < 16; ++c)
+		{
+			synthLib::SMidiEvent ev(synthLib::MidiEventSource::Editor, synthLib::M_CONTROLCHANGE + c, synthLib::MC_ALLNOTESOFF);
+			addMidiEvent(ev);
+		}
+	}
+
+	void Processor::panicNoteOffEveryNote()
+	{
+		for(uint8_t c = 0; c < 16; ++c)
+		{
+			for(uint8_t n = 0; n < 128; ++n)
+			{
+				synthLib::SMidiEvent ev(synthLib::MidiEventSource::Editor, synthLib::M_NOTEOFF + c, n, 64, n * 256);
+				addMidiEvent(ev);
+			}
+		}
+	}
+
+	void Processor::panicRebootDevice()
+	{
+		rebootDevice();
 	}
 
 	void Processor::addMidiEvent(const synthLib::SMidiEvent& _ev)

--- a/source/jucePluginLib/processor.h
+++ b/source/jucePluginLib/processor.h
@@ -69,6 +69,10 @@ namespace pluginLib
 
 		void addMidiEvent(const synthLib::SMidiEvent& _ev);
 
+		void panicAllNotesOff();
+		void panicNoteOffEveryNote();
+		void panicRebootDevice();
+
 		void handleIncomingMidiMessage(juce::MidiInput* _source, const juce::MidiMessage& _message);
 
 	    Controller& getController();

--- a/source/jucePluginLib/processor.h
+++ b/source/jucePluginLib/processor.h
@@ -89,6 +89,13 @@ namespace pluginLib
 			return m_controller.get();
 		}
 
+		// Const access to the controller without triggering lazy creation.
+		// Returns nullptr if the controller has not been created yet.
+		const Controller* getControllerConst() const
+		{
+			return m_controller.get();
+		}
+
 		virtual bool setLatencyBlocks(uint32_t _blocks);
 		virtual void updateLatencySamples();
 

--- a/source/juceRmlUi/CMakeLists.txt
+++ b/source/juceRmlUi/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 if(APPLE)
     # Universal or x86_64-only: scope flags to the x86_64 slice
     if(CMAKE_OSX_ARCHITECTURES MATCHES "x86_64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "x86|X86|amd64|AMD64")
-        target_compile_options(juceRmlUi PRIVATE -Xarch_x86_64 -mssse3 -Xarch_x86_64 -msse4.1)
+        target_compile_options(juceRmlUi PRIVATE "SHELL:-Xarch_x86_64 -mssse3" "SHELL:-Xarch_x86_64 -msse4.1")
     endif()
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86|X86|amd64|AMD64|i[3-6]86")
     include(CheckCXXCompilerFlag)

--- a/source/osTIrusJucePlugin/OsTIrusProcessor.cpp
+++ b/source/osTIrusJucePlugin/OsTIrusProcessor.cpp
@@ -10,6 +10,7 @@
 
 #include "jucePluginLib/controller.h"
 
+
 namespace
 {
 	juce::PropertiesFile::Options getConfigOptions()

--- a/source/osTIrusJucePlugin/OsTIrusProcessor.cpp
+++ b/source/osTIrusJucePlugin/OsTIrusProcessor.cpp
@@ -73,6 +73,9 @@ OsTIrusProcessor::~OsTIrusProcessor()
 
 void OsTIrusProcessor::audioProcessorParameterChangeGestureBegin(juce::AudioProcessor*, const int _parameterIndex)
 {
+	if(!getConfig().getBoolValue(g_clapSuggestPageKey, true))
+		return;
+
 	const auto& params = getParameters();
 	if(_parameterIndex < 0 || _parameterIndex >= static_cast<int>(params.size()))
 		return;

--- a/source/osTIrusJucePlugin/OsTIrusProcessor.cpp
+++ b/source/osTIrusJucePlugin/OsTIrusProcessor.cpp
@@ -49,11 +49,40 @@ OsTIrusProcessor::OsTIrusProcessor() :
 		m_remoteControlsPart = _part;
 		remoteControlsChanged();
 	});
+
+	// Build reverse lookup: parameter name → page index.
+	// Used to suggest the right remote controls page when the user touches a control.
+	for(uint32_t pageIdx = 0; pageIdx < virusTI::g_remoteControlsPageCount; ++pageIdx)
+	{
+		const auto& page = virusTI::g_remoteControlsPages[pageIdx];
+		for(const auto* name : page.params)
+		{
+			if(name)
+				m_paramNameToPage.emplace(name, pageIdx);
+		}
+	}
+
+	addListener(this);
 }
 
 OsTIrusProcessor::~OsTIrusProcessor()
 {
+	removeListener(this);
 	destroyEditorState();
+}
+
+void OsTIrusProcessor::audioProcessorParameterChangeGestureBegin(juce::AudioProcessor*, const int _parameterIndex)
+{
+	const auto& params = getParameters();
+	if(_parameterIndex < 0 || _parameterIndex >= static_cast<int>(params.size()))
+		return;
+
+	const auto name = params[_parameterIndex]->getName(255).toStdString();
+	const auto it   = m_paramNameToPage.find(name);
+	if(it == m_paramNameToPage.end())
+		return;
+
+	suggestRemoteControlsPage((it->second << 8) | m_remoteControlsPart);
 }
 
 uint32_t OsTIrusProcessor::remoteControlsPageCount() noexcept

--- a/source/osTIrusJucePlugin/OsTIrusProcessor.cpp
+++ b/source/osTIrusJucePlugin/OsTIrusProcessor.cpp
@@ -1,5 +1,6 @@
 #include "OsTIrusProcessor.h"
 #include "OsTIrusEditorState.h"
+#include "VirusTIRemoteControls.h"
 
 // ReSharper disable once CppUnusedIncludeDirective
 #include "BinaryData.h"
@@ -22,75 +23,7 @@ namespace
 	}
 }
 
-// ---------------------------------------------------------------------------
-// CLAP_EXT_REMOTE_CONTROLS — page table
-// ---------------------------------------------------------------------------
-namespace
-{
-	struct RemoteControlsPage
-	{
-		const char* sectionName;
-		const char* pageName;
-		// Exact "name" values from parameterDescriptions_TI.json; nullptr = empty slot.
-		const char* params[CLAP_REMOTE_CONTROLS_COUNT];
-	};
-
-	static constexpr RemoteControlsPage g_rcPages[] =
-	{
-		{ "Oscillators", "Oscillators",
-		  { "Osc1 Wave Select", "Osc1 Pulsewidth", "Osc1 Semitone",
-		    "Osc2 Wave Select", "Osc2 Pulsewidth", "Osc2 Detune", "Osc2 Semitone",
-		    "Osc2 FM Amount" } },
-
-		{ "Filter", "Filter",
-		  { "Cutoff", "Filter1 Resonance",
-		    "Cutoff2", "Filter2 Resonance",
-		    "Filter1 Env Amt", "Filter2 Env Amt",
-		    "Filter Balance", "Filter1 Keyfollow" } },
-
-		{ "Filter Envelope", "Filter Envelope",
-		  { "Filter Env Attack", "Filter Env Decay",
-		    "Filter Env Sustain", "Filter Env Sustain Time", "Filter Env Release",
-		    "Osc2 Filt Env Amt", "Filter1 Env Polarity", nullptr } },
-
-		{ "Amplifier", "Amplifier",
-		  { "Amp Env Attack", "Amp Env Decay",
-		    "Amp Env Sustain", "Amp Env Sustain Time", "Amp Env Release",
-		    "Patch Volume", "Panorama", nullptr } },
-
-		{ "LFO", "LFO 1",
-		  { "Lfo1 Rate", "Lfo1 Shape", "Lfo1 Symmetry",
-		    "Osc1 Lfo1 Amount", "Osc2 Lfo1 Amount",
-		    "PW Lfo1 Amount", "Reso Lfo1 Amount", "Lfo1 Mode" } },
-
-		{ "LFO", "LFO 2",
-		  { "Lfo2 Rate", "Lfo2 Shape", "Lfo2 Symmetry",
-		    "FM Lfo2 Amount", "Cutoff1 Lfo2 Amount", "Cutoff2 Lfo2 Amount",
-		    "Pan Lfo2 Amount", "Lfo2 Mode" } },
-
-		{ "Effects", "Reverb",
-		  { "Reverb Send", "Reverb Time", "Reverb Type",
-		    "Reverb Damping", "Reverb Color", "Reverb Predelay",
-		    "Reverb Feedback", "Reverb Mode" } },
-
-		{ "Effects", "Delay",
-		  { "Delay Send", "Delay Time", "Delay Feedback",
-		    "Delay Color", "Dly Rate / Rev Decay", "Dly Depth ",
-		    "Delay Type", "Delay Clock" } },
-
-		{ "Arpeggiator", "Arpeggiator",
-		  { "Arp Mode", "Arp Pattern Selct", "Arp Clock",
-		    "Arp Note Length", "Arp Octave Range", "Arp Hold Enable",
-		    "Arp Swing", "Clock Tempo" } },
-
-		{ "Performance", "Performance",
-		  { "Patch Volume", "Panorama", "Portamento Time", "Transpose",
-		    "Unison Detune", "Unison Pan Spread",
-		    "Bender Range Up", "Bender Range Down" } },
-	};
-
-	static constexpr uint32_t g_rcPageCount = static_cast<uint32_t>(std::size(g_rcPages));
-}
+// Page table lives in VirusTIRemoteControls.h
 
 //==============================================================================
 OsTIrusProcessor::OsTIrusProcessor() :
@@ -125,7 +58,7 @@ OsTIrusProcessor::~OsTIrusProcessor()
 
 uint32_t OsTIrusProcessor::remoteControlsPageCount() noexcept
 {
-	return g_rcPageCount;
+	return virusTI::g_remoteControlsPageCount;
 }
 
 bool OsTIrusProcessor::remoteControlsPageFill(
@@ -135,10 +68,10 @@ bool OsTIrusProcessor::remoteControlsPageFill(
 	juce::String& _pageName,
 	std::array<juce::AudioProcessorParameter*, CLAP_REMOTE_CONTROLS_COUNT>& _params) noexcept
 {
-	if(_pageIndex >= g_rcPageCount)
+	if(_pageIndex >= virusTI::g_remoteControlsPageCount)
 		return false;
 
-	const auto& page = g_rcPages[_pageIndex];
+	const auto& page = virusTI::g_remoteControlsPages[_pageIndex];
 	const auto* ctrl = getControllerConst();
 
 	_sectionName = page.sectionName;

--- a/source/osTIrusJucePlugin/OsTIrusProcessor.cpp
+++ b/source/osTIrusJucePlugin/OsTIrusProcessor.cpp
@@ -7,6 +7,8 @@
 
 #include "virusLib/romloader.h"
 
+#include "jucePluginLib/controller.h"
+
 namespace
 {
 	juce::PropertiesFile::Options getConfigOptions()
@@ -18,6 +20,76 @@ namespace
 		opts.osxLibrarySubFolder = "Application Support/DSP56300Emulator_OsTIrus";
 		return opts;
 	}
+}
+
+// ---------------------------------------------------------------------------
+// CLAP_EXT_REMOTE_CONTROLS — page table
+// ---------------------------------------------------------------------------
+namespace
+{
+	struct RemoteControlsPage
+	{
+		const char* sectionName;
+		const char* pageName;
+		// Exact "name" values from parameterDescriptions_TI.json; nullptr = empty slot.
+		const char* params[CLAP_REMOTE_CONTROLS_COUNT];
+	};
+
+	static constexpr RemoteControlsPage g_rcPages[] =
+	{
+		{ "Oscillators", "Oscillators",
+		  { "Osc1 Wave Select", "Osc1 Pulsewidth", "Osc1 Semitone",
+		    "Osc2 Wave Select", "Osc2 Pulsewidth", "Osc2 Detune", "Osc2 Semitone",
+		    "Osc2 FM Amount" } },
+
+		{ "Filter", "Filter",
+		  { "Cutoff", "Filter1 Resonance",
+		    "Cutoff2", "Filter2 Resonance",
+		    "Filter1 Env Amt", "Filter2 Env Amt",
+		    "Filter Balance", "Filter1 Keyfollow" } },
+
+		{ "Filter Envelope", "Filter Envelope",
+		  { "Filter Env Attack", "Filter Env Decay",
+		    "Filter Env Sustain", "Filter Env Sustain Time", "Filter Env Release",
+		    "Osc2 Filt Env Amt", "Filter1 Env Polarity", nullptr } },
+
+		{ "Amplifier", "Amplifier",
+		  { "Amp Env Attack", "Amp Env Decay",
+		    "Amp Env Sustain", "Amp Env Sustain Time", "Amp Env Release",
+		    "Patch Volume", "Panorama", nullptr } },
+
+		{ "LFO", "LFO 1",
+		  { "Lfo1 Rate", "Lfo1 Shape", "Lfo1 Symmetry",
+		    "Osc1 Lfo1 Amount", "Osc2 Lfo1 Amount",
+		    "PW Lfo1 Amount", "Reso Lfo1 Amount", "Lfo1 Mode" } },
+
+		{ "LFO", "LFO 2",
+		  { "Lfo2 Rate", "Lfo2 Shape", "Lfo2 Symmetry",
+		    "FM Lfo2 Amount", "Cutoff1 Lfo2 Amount", "Cutoff2 Lfo2 Amount",
+		    "Pan Lfo2 Amount", "Lfo2 Mode" } },
+
+		{ "Effects", "Reverb",
+		  { "Reverb Send", "Reverb Time", "Reverb Type",
+		    "Reverb Damping", "Reverb Color", "Reverb Predelay",
+		    "Reverb Feedback", "Reverb Mode" } },
+
+		{ "Effects", "Delay",
+		  { "Delay Send", "Delay Time", "Delay Feedback",
+		    "Delay Color", "Dly Rate / Rev Decay", "Dly Depth ",
+		    "Delay Type", "Delay Clock" } },
+
+		{ "Arpeggiator", "Arpeggiator",
+		  { "Arp Mode", "Arp Pattern Selct", "Arp Clock",
+		    "Arp Note Length", "Arp Octave Range", "Arp Hold Enable",
+		    "Arp Swing", "Clock Tempo" } },
+
+		{ "Performance", "Performance",
+		  { "Patch Volume", "Panorama", "Portamento Time", "Transpose",
+		    "Unison Detune", "Unison Pan Spread",
+		    "Bender Range Up", "Bender Range Down" } },
+	};
+
+	static constexpr uint32_t g_rcPageCount = static_cast<uint32_t>(std::size(g_rcPages));
 }
 
 //==============================================================================
@@ -36,11 +108,54 @@ OsTIrusProcessor::OsTIrusProcessor() :
 	, virusLib::DeviceModel::TI2)
 {
 	postConstruct(virusLib::ROMLoader::findROMs(virusLib::DeviceModel::TI2, virusLib::DeviceModel::Snow));
+
+	// Subscribe to part-selection changes so remote controls pages stay in sync.
+	// postConstruct() guarantees the controller exists at this point.
+	m_partChangedListener.set(getController().onCurrentPartChanged, [this](const uint8_t _part)
+	{
+		m_remoteControlsPart = _part;
+		remoteControlsChanged();
+	});
 }
 
 OsTIrusProcessor::~OsTIrusProcessor()
 {
 	destroyEditorState();
+}
+
+uint32_t OsTIrusProcessor::remoteControlsPageCount() noexcept
+{
+	return g_rcPageCount;
+}
+
+bool OsTIrusProcessor::remoteControlsPageFill(
+	const uint32_t _pageIndex,
+	juce::String& _sectionName,
+	uint32_t& _pageID,
+	juce::String& _pageName,
+	std::array<juce::AudioProcessorParameter*, CLAP_REMOTE_CONTROLS_COUNT>& _params) noexcept
+{
+	if(_pageIndex >= g_rcPageCount)
+		return false;
+
+	const auto& page = g_rcPages[_pageIndex];
+	const auto* ctrl = getControllerConst();
+
+	_sectionName = page.sectionName;
+	_pageName    = page.pageName;
+	// Encode page index + part into the ID so the host can distinguish sets
+	// across part changes while keeping page indices stable within a set.
+	_pageID = (_pageIndex << 8) | m_remoteControlsPart;
+
+	for(uint32_t i = 0; i < CLAP_REMOTE_CONTROLS_COUNT; ++i)
+	{
+		_params[i] = nullptr;
+		if(!ctrl || !page.params[i])
+			continue;
+		_params[i] = ctrl->getParameter(page.params[i], m_remoteControlsPart);
+	}
+
+	return true;
 }
 
 jucePluginEditorLib::PluginEditorState* OsTIrusProcessor::createEditorState()

--- a/source/osTIrusJucePlugin/OsTIrusProcessor.h
+++ b/source/osTIrusJucePlugin/OsTIrusProcessor.h
@@ -6,8 +6,12 @@
 
 #include "clap-juce-extensions/clap-juce-extensions.h"
 
+#include <string>
+#include <unordered_map>
+
 class OsTIrusProcessor : public virus::VirusProcessor,
-                          public clap_juce_extensions::clap_juce_audio_processor_capabilities
+                          public clap_juce_extensions::clap_juce_audio_processor_capabilities,
+                          public juce::AudioProcessorListener
 {
 public:
     OsTIrusProcessor();
@@ -22,9 +26,19 @@ public:
 	                            uint32_t& _pageID, juce::String& _pageName,
 	                            std::array<juce::AudioProcessorParameter*, CLAP_REMOTE_CONTROLS_COUNT>& _params) noexcept override;
 
+	// juce::AudioProcessorListener — used to detect parameter gesture begin
+	// and suggest the corresponding remote controls page to the host.
+	void audioProcessorParameterChanged(juce::AudioProcessor*, int, float) override {}
+	void audioProcessorChanged(juce::AudioProcessor*, const ChangeDetails&) override {}
+	void audioProcessorParameterChangeGestureBegin(juce::AudioProcessor*, int _parameterIndex) override;
+
 private:
 	// Part whose parameters the current remote control pages expose.
 	// Updated by the onCurrentPartChanged event; triggers a page refresh.
 	uint8_t                          m_remoteControlsPart = 0;
 	baseLib::EventListener<uint8_t>  m_partChangedListener;
+
+	// Reverse lookup built at startup: parameter name → page index.
+	// Used by audioProcessorParameterChangeGestureBegin to suggest pages.
+	std::unordered_map<std::string, uint32_t> m_paramNameToPage;
 };

--- a/source/osTIrusJucePlugin/OsTIrusProcessor.h
+++ b/source/osTIrusJucePlugin/OsTIrusProcessor.h
@@ -2,11 +2,28 @@
 
 #include "virusJucePlugin/VirusProcessor.h"
 
-class OsTIrusProcessor : public virus::VirusProcessor
+#include "baseLib/event.h"
+
+#include "clap-juce-extensions/clap-juce-extensions.h"
+
+class OsTIrusProcessor : public virus::VirusProcessor,
+                          public clap_juce_extensions::clap_juce_audio_processor_capabilities
 {
 public:
     OsTIrusProcessor();
     ~OsTIrusProcessor() override;
 
 	jucePluginEditorLib::PluginEditorState* createEditorState() override;
+
+	// CLAP_EXT_REMOTE_CONTROLS
+	uint32_t remoteControlsPageCount() noexcept override;
+	bool remoteControlsPageFill(uint32_t _pageIndex, juce::String& _sectionName,
+	                            uint32_t& _pageID, juce::String& _pageName,
+	                            std::array<juce::AudioProcessorParameter*, CLAP_REMOTE_CONTROLS_COUNT>& _params) noexcept override;
+
+private:
+	// Part whose parameters the current remote control pages expose.
+	// Updated by the onCurrentPartChanged event; triggers a page refresh.
+	uint8_t                          m_remoteControlsPart = 0;
+	baseLib::EventListener<uint8_t>  m_partChangedListener;
 };

--- a/source/osTIrusJucePlugin/OsTIrusProcessor.h
+++ b/source/osTIrusJucePlugin/OsTIrusProcessor.h
@@ -16,6 +16,7 @@ public:
 	jucePluginEditorLib::PluginEditorState* createEditorState() override;
 
 	// CLAP_EXT_REMOTE_CONTROLS
+	bool supportsRemoteControls() const noexcept override { return true; }
 	uint32_t remoteControlsPageCount() noexcept override;
 	bool remoteControlsPageFill(uint32_t _pageIndex, juce::String& _sectionName,
 	                            uint32_t& _pageID, juce::String& _pageName,

--- a/source/osTIrusJucePlugin/VirusTIRemoteControls.h
+++ b/source/osTIrusJucePlugin/VirusTIRemoteControls.h
@@ -1,0 +1,123 @@
+#pragma once
+
+// Remote controls page definitions for the Virus TI (OsTIrus).
+// Parameter names must match "name" fields in parameterDescriptions_TI.json exactly.
+// nullptr marks an unused slot (permitted by the CLAP spec).
+
+#include "clap-juce-extensions/clap-juce-extensions.h"
+
+namespace virusTI
+{
+	struct RemoteControlsPage
+	{
+		const char* sectionName;
+		const char* pageName;
+		const char* params[CLAP_REMOTE_CONTROLS_COUNT];
+	};
+
+	static constexpr RemoteControlsPage g_remoteControlsPages[] =
+	{
+		// ---- Sound sources --------------------------------------------------
+
+		{ "Oscillators", "Oscillator 1",
+		  { "Osc1 Wave Select", "Osc1 Shape",    "Osc1 Pulsewidth", "Osc1 Semitone",
+		    "Osc1 Keyfollow",   "Osc1 Mode",     "Noise Volume",    "Noise Color" } },
+
+		{ "Oscillators", "Oscillator 2",
+		  { "Osc2 Wave Select", "Osc2 Shape",    "Osc2 Pulsewidth", "Osc2 Semitone",
+		    "Osc2 Detune",      "Osc2 FM Amount","Osc2 Sync",       "Osc2 Filt Env Amt" } },
+
+		// ---- Filter ---------------------------------------------------------
+
+		{ "Filter", "Filter 1",
+		  { "Cutoff",          "Filter1 Resonance", "Filter1 Env Amt",     "Filter1 Keyfollow",
+		    "Filter1 Mode",    "Filter1 Env Polarity", "Filter Select",    "Filter Routing" } },
+
+		{ "Filter", "Filter 2",
+		  { "Cutoff2",         "Filter2 Resonance", "Filter2 Env Amt",     "Filter2 Keyfollow",
+		    "Cutoff2 Offset",  "Filter Balance",    "Filter2 Mode",        nullptr } },
+
+		{ "Filter", "Filter Envelope",
+		  { "Filter Env Attack", "Filter Env Decay",        "Filter Env Sustain",
+		    "Filter Env Sustain Time", "Filter Env Release", "Osc2 Filt Env Amt",
+		    "Filter1 Env Polarity",    nullptr } },
+
+		// ---- Amplifier ------------------------------------------------------
+
+		{ "Amplifier", "Amplifier",
+		  { "Amp Env Attack", "Amp Env Decay",        "Amp Env Sustain",
+		    "Amp Env Sustain Time", "Amp Env Release", "Patch Volume",
+		    "Panorama",       nullptr } },
+
+		// ---- LFOs -----------------------------------------------------------
+
+		{ "LFO", "LFO 1",
+		  { "Lfo1 Rate",        "Lfo1 Shape",        "Lfo1 Symmetry",
+		    "Osc1 Lfo1 Amount", "Osc2 Lfo1 Amount",  "PW Lfo1 Amount",
+		    "Reso Lfo1 Amount", "Lfo1 Mode" } },
+
+		{ "LFO", "LFO 2",
+		  { "Lfo2 Rate",         "Lfo2 Shape",          "Lfo2 Symmetry",
+		    "FM Lfo2 Amount",    "Cutoff1 Lfo2 Amount", "Cutoff2 Lfo2 Amount",
+		    "Pan Lfo2 Amount",   "Lfo2 Mode" } },
+
+		{ "LFO", "LFO 3",
+		  { "Lfo3 Rate",       "Lfo3 Shape",        "Lfo3 Mode",
+		    "Lfo3 Destination","Osc Lfo3 Amount",   "Lfo3 Fade-In Time",
+		    "Lfo3 Keyfollow",  "Lfo3 Clock" } },
+
+		// ---- Effects --------------------------------------------------------
+
+		{ "Effects", "Chorus",
+		  { "Chorus Mix",      "Chorus Rate",    "Chorus Depth",    "Chorus Delay",
+		    "Chorus Feedback", "Chorus Lfo Shape","Chorus/Type",    nullptr } },
+
+		{ "Effects", "Phaser",
+		  { "Phaser Mix",      "Phaser Rate",    "Phaser Depth",    "Phaser Frequency",
+		    "Phaser Feedback", "Phaser Spread",  "Phaser Mode",     nullptr } },
+
+		{ "Effects", "Reverb",
+		  { "Reverb Send",    "Reverb Time",     "Reverb Type",   "Reverb Damping",
+		    "Reverb Color",   "Reverb Predelay", "Reverb Feedback","Reverb Mode" } },
+
+		{ "Effects", "Delay",
+		  { "Delay Send",           "Delay Time",          "Delay Feedback",  "Delay Color",
+		    "Dly Rate / Rev Decay", "Dly Depth ",          "Delay Type",      "Delay Clock" } },
+
+		// ---- FX1 section ----------------------------------------------------
+
+		// Context-dependent: indices 21-24 change display name with Filter Bank/Type
+		// but the underlying parameter is the same — controller resolves by name.
+		{ "FX1", "Filter Bank",
+		  { "Filter Bank/Type",        "Filter Bank/Mix",         "Filter Bank/Frequency",
+		    "Filter Bank/Resonance",   "Filter Bank/Stereo Phase","Filter Bank/Filter Type",
+		    "Filter Bank/Slope",       nullptr } },
+
+		// Patch Distortion sub-section of FX1
+		{ "FX1", "Distortion",
+		  { "Distortion Curve",            "Distortion Intensity",
+		    "Patch Distortion/Mix",        "Patch Distortion/Treble Booster",
+		    "Patch Distortion/High Cut",   "Patch Distortion/Tone127",
+		    "Bass Intensity",              "Punch Intensity" } },
+
+		// 3-band EQ: 7 params, one empty slot
+		{ "FX1", "EQ",
+		  { "LowEQ Gain",    "LowEQ Frequency",
+		    "MidEQ Gain",    "MidEQ Frequency",  "MidEQ Q-Factor",
+		    "HighEQ Gain",   "HighEQ Frequency", nullptr } },
+
+		// ---- Arpeggiator & Performance --------------------------------------
+
+		{ "Arpeggiator", "Arpeggiator",
+		  { "Arp Mode",        "Arp Pattern Selct", "Arp Clock",        "Arp Note Length",
+		    "Arp Octave Range","Arp Hold Enable",   "Arp Swing",        "Clock Tempo" } },
+
+		{ "Performance", "Performance",
+		  { "Patch Volume",   "Panorama",         "Portamento Time",  "Transpose",
+		    "Unison Detune",  "Unison Pan Spread", "Bender Range Up", "Bender Range Down" } },
+	};
+
+	static constexpr uint32_t g_remoteControlsPageCount =
+		static_cast<uint32_t>(std::size(g_remoteControlsPages));
+
+} // namespace virusTI

--- a/source/osTIrusJucePlugin/tus_settings_gui_OsTIrus.rml
+++ b/source/osTIrusJucePlugin/tus_settings_gui_OsTIrus.rml
@@ -10,5 +10,14 @@
 		<button id="button" class="settings-checkbox"/>
 		<label>Enable Logo Animation</label>
 	</div>
+	<settingsspacer1/>
+	<div id="clapSection">
+		<h1>CLAP Controller Integration</h1>
+		<settingsspacer1/>
+		<div id="btClapSuggestPage" class="settings-checkboxwithlabel">
+			<button id="button" class="settings-checkbox"/>
+			<label>Suggest remote controls page on touch</label>
+		</div>
+	</div>
 </body>
 </template>

--- a/source/osTIrusJucePlugin/tus_settings_gui_OsTIrus.rml
+++ b/source/osTIrusJucePlugin/tus_settings_gui_OsTIrus.rml
@@ -3,12 +3,14 @@
 	<link type="text/rcss" href="tus_settings_gui_OsTIrus.rcss"/>
 </head>
 <body>
-	<settingsspacer1/>
-	<h1>Animation</h1>
-	<settingsspacer1/>
-	<div id="btEnableLogoAnimations" class="settings-checkboxwithlabel">
-		<button id="button" class="settings-checkbox"/>
-		<label>Enable Logo Animation</label>
+	<div id="animationSection">
+		<settingsspacer1/>
+		<h1>Animation</h1>
+		<settingsspacer1/>
+		<div id="btEnableLogoAnimations" class="settings-checkboxwithlabel">
+			<button id="button" class="settings-checkbox"/>
+			<label>Enable Logo Animation</label>
+		</div>
 	</div>
 	<settingsspacer1/>
 	<div id="clapSection">

--- a/source/synthLib/midiClock.cpp
+++ b/source/synthLib/midiClock.cpp
@@ -39,6 +39,15 @@ namespace synthLib
 			LOGMC("Stop at ppqPos=" << _ppqPos);
 			stop();
 		}
+		else if(m_isPlaying && _isPlaying && _ppqPos < m_lastPpqPos - 0.5)
+		{
+			// Host looped back or seeked backward — re-sync the clock
+			LOGMC("Loop/seek detected: ppqPos " << m_lastPpqPos << " -> " << _ppqPos);
+			stop();
+			start(_ppqPos);
+		}
+
+		m_lastPpqPos = _ppqPos;
 
 		for(uint32_t i=0; i<static_cast<uint32_t>(_sampleCount); ++i)
 		{
@@ -66,10 +75,18 @@ namespace synthLib
 	void MidiClock::start(const float _ppqPos)
 	{
 		const double ppqPos = _ppqPos;
-		const auto quarterPos = (ppqPos - std::floor(ppqPos + 1.0));
 
-		m_clockTickPos = quarterPos * (ClockTicksPerQuarter);
+		// Compute how far through the current clock tick period we already are,
+		// so the first tick fires at the correct phase rather than always at the
+		// start of the next full tick period.
+		// m_clockTickPos must be in [-1, 0): the loop fires a tick each time it
+		// crosses 0, so starting at (fracTick - 1.0) fires the first tick after
+		// exactly (1 - fracTick) of a tick period.
+		const double absoluteTicks = ppqPos * ClockTicksPerQuarter;
+		const double fracTick = absoluteTicks - std::floor(absoluteTicks);
+		m_clockTickPos = fracTick - 1.0;
 
+		m_lastPpqPos = ppqPos;
 		m_isPlaying = true;
 
 		LOGMC("Start at ppqPos=" << ppqPos << ", clock tick offset " << m_clockTickPos);

--- a/source/synthLib/midiClock.h
+++ b/source/synthLib/midiClock.h
@@ -24,5 +24,6 @@ namespace synthLib
 
 		bool m_isPlaying = false;
 		double m_clockTickPos = 0.0;
+		double m_lastPpqPos = 0.0;
 	};
 }

--- a/source/virusJucePlugin/ParameterNames.h
+++ b/source/virusJucePlugin/ParameterNames.h
@@ -3,6 +3,11 @@
 namespace virus
 {
 	static constexpr char g_paramDelayReverbMode[] = "Delay/Reverb Mode";
+	static constexpr char g_paramReverbSend[]      = "Reverb Send";
+	static constexpr char g_paramReverbTime[]      = "Reverb Time";
+	static constexpr char g_paramDelaySend[]       = "Delay Send";
+	static constexpr char g_paramDelayTime[]       = "Delay Time";
+	static constexpr char g_paramDelayFeedback[]   = "Delay Feedback";
 	static constexpr char g_paramPartVolume[] = "Part Volume";
 	static constexpr char g_paramPatchVolume[] = "Patch Volume";
 	static constexpr char g_paramPartPanorama[] = "Panorama";

--- a/source/virusJucePlugin/SettingsGuiOsTIrus.cpp
+++ b/source/virusJucePlugin/SettingsGuiOsTIrus.cpp
@@ -13,23 +13,27 @@ namespace genericVirusUI
 	{
 		auto* leds = _editor->getLeds().get();
 
+		// ---- Logo animation -------------------------------------------------
+		// Hide only the animation section when the skin has no logo element;
+		// other sections (CLAP, future) are unaffected.
 		if(!leds || !leds->supportsLogoAnimation())
 		{
-			juceRmlUi::helper::setVisible(_root, false);
-			return;
+			if(auto* animSection = juceRmlUi::helper::findChild(_root, "animationSection"))
+				juceRmlUi::helper::setVisible(animSection, false);
 		}
-
-		// ---- Logo animation -------------------------------------------------
-		auto* button = juceRmlUi::helper::findChild(_root, "btEnableLogoAnimations");
-		auto* buttonComp = juceRmlUi::helper::findChildT<juceRmlUi::ElemButton>(button, "button");
-
-		buttonComp->setChecked(leds->isLogoAnimationEnabled());
-
-		juceRmlUi::EventListener::AddClick(button, [leds, buttonComp]
+		else
 		{
-			leds->toggleLogoAnimation();
+			auto* button     = juceRmlUi::helper::findChild(_root, "btEnableLogoAnimations");
+			auto* buttonComp = juceRmlUi::helper::findChildT<juceRmlUi::ElemButton>(button, "button");
+
 			buttonComp->setChecked(leds->isLogoAnimationEnabled());
-		});
+
+			juceRmlUi::EventListener::AddClick(button, [leds, buttonComp]
+			{
+				leds->toggleLogoAnimation();
+				buttonComp->setChecked(leds->isLogoAnimationEnabled());
+			});
+		}
 
 #ifdef HAS_CLAP_JUCE_EXTENSIONS
 		// ---- CLAP: suggest remote controls page on gesture ------------------

--- a/source/virusJucePlugin/SettingsGuiOsTIrus.cpp
+++ b/source/virusJucePlugin/SettingsGuiOsTIrus.cpp
@@ -35,11 +35,10 @@ namespace genericVirusUI
 			});
 		}
 
-#ifdef HAS_CLAP_JUCE_EXTENSIONS
 		// ---- CLAP: suggest remote controls page on gesture ------------------
-		auto& config = _editor->getProcessor().getConfig();
-
-		auto* clapSection   = juceRmlUi::helper::findChild(_root, "clapSection");
+		// The section is always shown; the config key is only acted upon by
+		// OsTIrusProcessor when running as a CLAP plugin.
+		auto& config        = _editor->getProcessor().getConfig();
 		auto* btSuggest     = juceRmlUi::helper::findChild(_root, "btClapSuggestPage");
 		auto* btSuggestComp = juceRmlUi::helper::findChildT<juceRmlUi::ElemButton>(btSuggest, "button");
 
@@ -52,10 +51,5 @@ namespace genericVirusUI
 			config.saveIfNeeded();
 			btSuggestComp->setChecked(newValue);
 		});
-#else
-		// Hide the CLAP section in non-CLAP builds
-		if(auto* clapSection = juceRmlUi::helper::findChild(_root, "clapSection"))
-			juceRmlUi::helper::setVisible(clapSection, false);
-#endif
 	}
 }

--- a/source/virusJucePlugin/SettingsGuiOsTIrus.cpp
+++ b/source/virusJucePlugin/SettingsGuiOsTIrus.cpp
@@ -1,6 +1,7 @@
 #include "SettingsGuiOsTIrus.h"
 
 #include "VirusEditor.h"
+#include "VirusProcessor.h"
 
 #include "juceRmlUi/rmlElemButton.h"
 #include "juceRmlUi/rmlEventListener.h"
@@ -18,8 +19,8 @@ namespace genericVirusUI
 			return;
 		}
 
+		// ---- Logo animation -------------------------------------------------
 		auto* button = juceRmlUi::helper::findChild(_root, "btEnableLogoAnimations");
-
 		auto* buttonComp = juceRmlUi::helper::findChildT<juceRmlUi::ElemButton>(button, "button");
 
 		buttonComp->setChecked(leds->isLogoAnimationEnabled());
@@ -27,8 +28,30 @@ namespace genericVirusUI
 		juceRmlUi::EventListener::AddClick(button, [leds, buttonComp]
 		{
 			leds->toggleLogoAnimation();
-
 			buttonComp->setChecked(leds->isLogoAnimationEnabled());
 		});
+
+#ifdef HAS_CLAP_JUCE_EXTENSIONS
+		// ---- CLAP: suggest remote controls page on gesture ------------------
+		auto& config = _editor->getProcessor().getConfig();
+
+		auto* clapSection   = juceRmlUi::helper::findChild(_root, "clapSection");
+		auto* btSuggest     = juceRmlUi::helper::findChild(_root, "btClapSuggestPage");
+		auto* btSuggestComp = juceRmlUi::helper::findChildT<juceRmlUi::ElemButton>(btSuggest, "button");
+
+		btSuggestComp->setChecked(config.getBoolValue(virus::VirusProcessor::g_clapSuggestPageKey, true));
+
+		juceRmlUi::EventListener::AddClick(btSuggest, [&config, btSuggestComp]
+		{
+			const bool newValue = !config.getBoolValue(virus::VirusProcessor::g_clapSuggestPageKey, true);
+			config.setValue(virus::VirusProcessor::g_clapSuggestPageKey, newValue);
+			config.saveIfNeeded();
+			btSuggestComp->setChecked(newValue);
+		});
+#else
+		// Hide the CLAP section in non-CLAP builds
+		if(auto* clapSection = juceRmlUi::helper::findChild(_root, "clapSection"))
+			juceRmlUi::helper::setVisible(clapSection, false);
+#endif
 	}
 }

--- a/source/virusJucePlugin/VirusEditor.cpp
+++ b/source/virusJucePlugin/VirusEditor.cpp
@@ -115,6 +115,15 @@ namespace genericVirusUI
 
 		m_deviceModel = findChild("DeviceModel", false);
 
+		if(auto* bt = findChild("btPanicAllNotesOff", false))
+			juceRmlUi::EventListener::AddClick(bt, [this] { m_processor.panicAllNotesOff(); });
+
+		if(auto* bt = findChild("btPanicNoteOffEveryNote", false))
+			juceRmlUi::EventListener::AddClick(bt, [this] { m_processor.panicNoteOffEveryNote(); });
+
+		if(auto* bt = findChild("btPanicReboot", false))
+			juceRmlUi::EventListener::AddClick(bt, [this] { m_processor.panicRebootDevice(); });
+
 		auto* presetSave = findChild("PresetSave", false);
 		if(presetSave)
 			juceRmlUi::EventListener::Add(presetSave, Rml::EventId::Click, [this](Rml::Event& _event) { savePreset(_event); });

--- a/source/virusJucePlugin/VirusProcessor.cpp
+++ b/source/virusJucePlugin/VirusProcessor.cpp
@@ -219,3 +219,43 @@ namespace virus
 		}
 	}
 }
+
+double virus::VirusProcessor::getTailLengthSeconds() const
+{
+	const auto* ctrl = getControllerConst();
+	if(!ctrl)
+		return 0.0;
+
+	double tail = 0.0;
+
+	// Reverb tail.
+	// Virus TI hardware: Reverb Time (page 110, index 4) is 0–127 and maps to
+	// approximately 0–16 seconds of decay at the hardware level.
+	// Only contributes if Reverb Send is non-zero.
+	const auto* reverbSend = ctrl->getParameter(g_paramReverbSend, 0);
+	const auto* reverbTime = ctrl->getParameter(g_paramReverbTime, 0);
+	if(reverbSend && reverbTime && reverbSend->getUnnormalizedValue() > 0)
+	{
+		constexpr double kMaxReverbSeconds = 16.0;
+		tail = std::max(tail, (reverbTime->getUnnormalizedValue() / 127.0) * kMaxReverbSeconds);
+	}
+
+	// Delay tail.
+	// Delay Time 0–127 → 0–1000 ms (free-running mode).
+	// Feedback determines how many repetitions ring out:
+	//   effective tail ≈ delayTime / (1 – feedback), capped at 30 s to avoid infinity.
+	const auto* delaySend     = ctrl->getParameter(g_paramDelaySend,     0);
+	const auto* delayTime     = ctrl->getParameter(g_paramDelayTime,     0);
+	const auto* delayFeedback = ctrl->getParameter(g_paramDelayFeedback, 0);
+	if(delaySend && delayTime && delayFeedback && delaySend->getUnnormalizedValue() > 0)
+	{
+		constexpr double kMaxDelaySeconds  = 30.0;
+		constexpr double kDelayTimeRangeMs = 1000.0;
+		const double delaySeconds  = (delayTime->getUnnormalizedValue() / 127.0) * (kDelayTimeRangeMs / 1000.0);
+		const double feedback      = delayFeedback->getUnnormalizedValue() / 127.0;
+		const double delayTail     = feedback < 0.99 ? delaySeconds / (1.0 - feedback) : kMaxDelaySeconds;
+		tail = std::max(tail, std::min(delayTail, kMaxDelaySeconds));
+	}
+
+	return tail;
+}

--- a/source/virusJucePlugin/VirusProcessor.h
+++ b/source/virusJucePlugin/VirusProcessor.h
@@ -16,6 +16,7 @@ namespace virus
 	    ~VirusProcessor() override;
 
 	    void processBpm(float _bpm) override;
+		double getTailLengthSeconds() const override;
 
 		// _____________
 		//

--- a/source/virusJucePlugin/VirusProcessor.h
+++ b/source/virusJucePlugin/VirusProcessor.h
@@ -81,10 +81,8 @@ namespace virus
 	public:
 	    baseLib::Event<const virusLib::ROMFile*> evRomChanged;
 
-#ifdef HAS_CLAP_JUCE_EXTENSIONS
 		// Config key for the "suggest remote controls page on gesture" preference.
-		// Read/written by OsTIrusProcessor and SettingsGuiOsTIrus via getConfig().
+		// Read/written by OsTIrusProcessor (CLAP) and SettingsGuiOsTIrus via getConfig().
 		static constexpr const char* const g_clapSuggestPageKey = "clapSuggestPage";
-#endif
 	};
 }

--- a/source/virusJucePlugin/VirusProcessor.h
+++ b/source/virusJucePlugin/VirusProcessor.h
@@ -80,5 +80,11 @@ namespace virus
 
 	public:
 	    baseLib::Event<const virusLib::ROMFile*> evRomChanged;
+
+#ifdef HAS_CLAP_JUCE_EXTENSIONS
+		// Config key for the "suggest remote controls page on gesture" preference.
+		// Read/written by OsTIrusProcessor and SettingsGuiOsTIrus via getConfig().
+		static constexpr const char* const g_clapSuggestPageKey = "clapSuggestPage";
+#endif
 	};
 }


### PR DESCRIPTION
### Expose panic actions to main skin via button IDs

- Moves panic logic (`panicAllNotesOff`, `panicNoteOffEveryNote`, `panicRebootDevice`) from `SettingsMidi` into `Processor` — single authoritative location
- `SettingsMidi` delegates to the new methods (no behaviour change for the settings page)
- Registers click handlers in `VirusEditor::create(` for `btPanicAllNotesOff`, `btPanicNoteOffEveryNote`, `btPanicReboot` — silently skipped when absent, so existing skins are unaffected

Skin usage — no params, no Lua needed:

```rml
<button id="btPanicAllNotesOff"      class="jucePos juceButton" isToggle="0" style="...">!</button>
<button id="btPanicNoteOffEveryNote" class="jucePos juceButton" isToggle="0" style="...">!</button>
<button id="btPanicReboot"           class="jucePos juceButton" isToggle="0" style="...">!</button>
```

### Why this matters

Stuck notes and runaway reverb/delay tails are a real problem during live performance and studio sessions. On the original Virus TI hardware, Access provided a dedicated panic shortcut (MONO+SYNC held simultaneously) for exactly this reason.

In the emulator the situation was worse than it might appear:

- **CC123 (All Notes Off)** from a hardware controller already works — it passes straight through to the firmware. But it does nothing to reverb/delay tails, which live in DSP memory and keep running regardless of voice state. Also, users without hardware controller have to dig their way through the settings for pulling killswitch.
- **The settings page panic buttons were the only way to truly stop sound** — requiring two or three clicks through a menu, far too slow when something goes wrong live.
- **Reboot Device** is the only option that actually silences everything — it recreates the DSP from scratch, equivalent to what the hardware **MONO+SYNC** shortcut likely does internally.
- This PR makes all three panic actions available as first-class skin buttons, so a skin developer can place an immediately accessible panic button directly on the instrument surface — the same way hardware synths expose it as a front-panel control. No new plugin parameters, no automation lanes, no MIDI learn slots consumed. Skins that don't use the buttons pay no cost.