### PR TITLE
Fix juceRmlUi universal build on Apple Silicon (msse4.1 leak to arm64 slice)

### DIFF
--- a/source/juceRmlUi/CMakeLists.txt
+++ b/source/juceRmlUi/CMakeLists.txt
@@ -78,7 +78,11 @@ endif()
 if(APPLE)
     # Universal or x86_64-only: scope flags to the x86_64 slice
     if(CMAKE_OSX_ARCHITECTURES MATCHES "x86_64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "x86|X86|amd64|AMD64")
-        target_compile_options(juceRmlUi PRIVATE -Xarch_x86_64 -mssse3 -Xarch_x86_64 -msse4.1)
+        # Use SHELL: prefix so CMake doesn't deduplicate the second -Xarch_x86_64
+        # (which would leave -msse4.1 unwrapped, causing arm64 slice to fail).
+        target_compile_options(juceRmlUi PRIVATE
+            "SHELL:-Xarch_x86_64 -mssse3"
+            "SHELL:-Xarch_x86_64 -msse4.1")
     endif()
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86|X86|amd64|AMD64|i[3-6]86")
     include(CheckCXXCompilerFlag)


### PR DESCRIPTION
## Summary

Wrap the x86-only SSE compile flags in `source/juceRmlUi/CMakeLists.txt` with the CMake `SHELL:` prefix so they aren't split/deduplicated by CMake's argument processing. Before this fix, macOS universal builds (`x86_64;arm64`) failed during the arm64 slice with:

```
clang: error: unsupported option '-msse4.1' for target 'arm64-apple-macos10.13'
```

## Root cause

The previous code was:

```cmake
target_compile_options(juceRmlUi PRIVATE -Xarch_x86_64 -mssse3 -Xarch_x86_64 -msse4.1)
```

CMake sees this as 4 individual arguments and deduplicates the second `-Xarch_x86_64` token (it matches the first). The flags reaching clang are therefore `-Xarch_x86_64 -mssse3 -msse4.1` — `-msse4.1` is orphaned. On the x86_64 slice clang silently accepts the orphan, but on the arm64 slice clang errors out because SSE doesn't exist on ARM.

You can see the symptom in the build log:

```
clang: warning: argument unused during compilation: '-Xarch_x86_64 -mssse3' [-Wunused-command-line-argument]
clang: error: unsupported option '-msse4.1' for target 'arm64-apple-macos10.13'
```

The first pair stayed together (and is correctly skipped on arm64); the second `-msse4.1` came through unwrapped.

## Fix

Use CMake's `SHELL:` prefix so each `-Xarch_x86_64 -msseN.N` pair is treated as an atomic group and not deduplicated:

```cmake
target_compile_options(juceRmlUi PRIVATE
    "SHELL:-Xarch_x86_64 -mssse3"
    "SHELL:-Xarch_x86_64 -msse4.1")
```

The intent (apply SSE flags only to the x86_64 slice in universal builds, rely on `sse2neon` for the NEON-side intrinsics) is preserved; this just stops CMake from breaking the pairing.

## Test plan

- [x] Reproduced the build failure on macOS 15.5 + Xcode 16.4 + CMake 4.3.2 (universal build, arm64+x86_64)
- [x] Confirmed fix lets the arm64 slice of `juceRmlUi` compile cleanly
- [x] Full `build_mac.sh` Release universal build proceeds past the previous failure point
- [ ] Reviewers: please verify on Intel Mac and Linux to confirm no regressions in the x86_64 paths

## Notes

- No behavioral change for x86_64 builds or for non-Apple targets (the `elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86|...")` branch is unchanged).
- The fix is minimal: 1 line replaced with 4 (3 of which are comments + formatting).