### PR TITLE
Fix Patch Manager search-handle leaks causing unbounded CPU growth

### DIFF
--- a/source/jucePluginEditorLib/patchmanager/patchmanager.cpp
+++ b/source/jucePluginEditorLib/patchmanager/patchmanager.cpp
@@ -644,7 +644,16 @@ namespace jucePluginEditorLib::patchManager
 			results.assign(_search.results.begin(), _search.results.end());
 
 			if(results.empty())
+			{
+				// the search found no match, but it must still be cancelled/removed from the DB's
+				// search list, otherwise it leaks forever and every subsequent bank load / patch
+				// update has to scan it in DB::updateSearches, causing CPU usage to grow unbounded
+				runOnUiThread([this, handle]
+				{
+					cancelSearch(handle);
+				});
 				return;
+			}
 
 			if(results.size() > 1)
 			{

--- a/source/jucePluginLib/patchdb/db.cpp
+++ b/source/jucePluginLib/patchdb/db.cpp
@@ -480,7 +480,14 @@ namespace pluginLib::patchDB
 			return;
 
 		std::unique_lock lock(m_searchesMutex);
-		m_cancelledSearches.insert(_handle);
+
+		// only remember the handle as cancelled if the search may still be picked up by executeSearch
+		// later (i.e. it's still queued/running). A search that has already completed will never be
+		// looked at again, so tracking it here would leak the handle in m_cancelledSearches forever.
+		const auto it = m_searches.find(_handle);
+		if(it != m_searches.end() && it->second->state != SearchState::Completed)
+			m_cancelledSearches.insert(_handle);
+
 		m_searches.erase(_handle);
 	}
 


### PR DESCRIPTION
## Summary

Two related leaks in the Patch Manager's search-handle bookkeeping (`pluginLib::patchDB::DB`) that cause plugin host CPU usage to climb after loading multiple banks / switching many patches, and never recover:

- `PatchManager::updateStateAsync()` only called `cancelSearch()` on the "found a datasource match" path; the "no match found" early return skipped it, so the `Search` stayed in `DB::m_searches` forever. Since `DB::updateSearches()` rescans every entry in `m_searches` (including leaked ones) against every newly loaded patch on each subsequent bank load/patch change, leaked searches make every future load do strictly more work, with cost proportional to cumulative history rather than current state.
- `DB::cancelSearch()` always inserted the handle into `m_cancelledSearches`, but that set is only ever pruned inside `executeSearch()`'s per-datasource cancellation check, which never runs for a search that has already completed — the common case for essentially every Patch Manager UI interaction (tree/list rebuilds, filtering, patch selection). This is a genuine unbounded memory leak, distinct in character from the first (insert/find/erase only, never iterated, so not itself a CPU driver).

Both were found while investigating Bitwig host CPU climbing to 150-170% and never dropping back after loading several banks and switching patches in Osirus/OsTIrus.

## Changes

- `updateStateAsync()`: dispatch `cancelSearch(handle)` on the empty-results path too, mirroring the already-correct success path.
- `cancelSearch()`: only track a handle in `m_cancelledSearches` if the search hasn't completed yet, since a completed search will never be looked at again.

## Test plan

- [x] Builds clean (`jucePluginLib`, `jucePluginEditorLib` targets, Xcode/macOS)
- [x] Reproduced the original symptom (Osirus/OsTIrus CLAP in Bitwig: load several banks, switch many patches, CPU climbs and doesn't recover) and confirmed CPU stays flat after this fix