### PR TITLE
Fix MIDI-Learn listener leak and prevent macOS App Nap throttling

### DIFF
--- a/source/jucePluginLib/midiLearnTranslator.cpp
+++ b/source/jucePluginLib/midiLearnTranslator.cpp
@@ -355,7 +355,7 @@ namespace pluginLib
 	void MidiLearnTranslator::subscribeToParameters()
 	{
 		const auto& mappings = m_preset.getMappings();
-		m_paramListenerIds.reserve(mappings.size());
+		m_paramListeners.reserve(mappings.size());
 
 		for (const auto& mapping : mappings)
 		{
@@ -380,23 +380,19 @@ namespace pluginLib
 					onParameterChanged(paramName, _param->getValue(), origin);
 				});
 
-			m_paramListenerIds.push_back(listenerId);
+			m_paramListeners.emplace_back(param, listenerId);
 		}
 	}
 
 	void MidiLearnTranslator::unsubscribeFromParameters()
 	{
-		const auto& mappings = m_preset.getMappings();
-		
-		// Remove listeners
-		for (size_t i = 0; i < m_paramListenerIds.size() && i < mappings.size(); ++i)
-		{
-			auto* param = m_controller.getParameter(mappings[i].paramName, 0);
-			if (param)
-				param->onValueChanged.removeListener(m_paramListenerIds[i]);
-		}
+		// Remove each listener from the exact parameter it was attached to. This is independent
+		// of the current mapping list, so it stays correct even if mappings were skipped during
+		// subscribe or the preset changed in between.
+		for (const auto& [param, listenerId] : m_paramListeners)
+			param->onValueChanged.removeListener(listenerId);
 
-		m_paramListenerIds.clear();
+		m_paramListeners.clear();
 	}
 
 	void MidiLearnTranslator::onParameterChanged(const std::string& _paramName, float _normalizedValue, Parameter::Origin _origin)

--- a/source/jucePluginLib/midiLearnTranslator.h
+++ b/source/jucePluginLib/midiLearnTranslator.h
@@ -82,8 +82,11 @@ namespace pluginLib
 		uint8_t m_learnInputSources = (1<<static_cast<uint8_t>(synthLib::MidiEventSource::Host)) | (1<<static_cast<uint8_t>(synthLib::MidiEventSource::Physical)); // Host | Physical - both enabled by default
 		static constexpr size_t kRequiredUniqueValues = 2; // Need 2 unique values (both directions)
 
-		// Parameter subscriptions for feedback
-		std::vector<baseLib::Event<Parameter*>::ListenerId> m_paramListenerIds;
+		// Parameter subscriptions for feedback. Store each listener together with the exact
+		// parameter it was attached to, so unsubscribe removes it from the right event
+		// regardless of mapping order or skipped mappings (previously indexed by mapping,
+		// which leaked listeners whenever any mapping was skipped during subscribe).
+		std::vector<std::pair<Parameter*, baseLib::Event<Parameter*>::ListenerId>> m_paramListeners;
 
 		// Cache for quick lookup: key = (channel << 8) | controller
 		std::unordered_map<uint32_t, size_t> m_midiToMappingIndex;

--- a/source/jucePluginLib/processor.h
+++ b/source/jucePluginLib/processor.h
@@ -248,5 +248,10 @@ namespace pluginLib
 		// Host MIDI feedback queue (filled from parameter listeners, drained in processBlock)
 		std::mutex m_hostFeedbackMutex;
 		std::vector<synthLib::SMidiEvent> m_hostFeedbackQueue;
+
+		// Keeps the process out of macOS App Nap for the plugin's lifetime. Without this, macOS can demote the
+		// whole plugin-host process into a lower-power scheduling state once it decides the process isn't
+		// interactive, independent of any individual thread's own QoS/priority settings.
+		juce::ScopedLowPowerModeDisabler m_lowPowerModeDisabler;
 	};
 }


### PR DESCRIPTION
## Summary
- `MidiLearnTranslator::unsubscribeFromParameters()` removed listeners by indexing into the *current* mapping list, but `subscribeToParameters()` skips mappings whose parameter can't be resolved. Once the mapping list and listener-ID list went out of sync this way, any subsequently-skipped or reordered mapping caused its listener to never be removed - a permanent leak. Fixed by storing each listener together with the exact parameter it was attached to, so removal no longer depends on the mapping list's shape.
- Added a `juce::ScopedLowPowerModeDisabler` member to `Processor`, held for the plugin's lifetime, to opt the process out of macOS App Nap. Without it, macOS can demote the whole plugin-host process into a lower-power scheduling state once it decides the process isn't interactive, independent of any individual thread's own QoS/realtime priority settings.

Both were found while investigating a real-world CPU usage report on OsTIrus in Bitwig on macOS. Neither turned out to explain that specific symptom (which further investigation points to being macOS/SoC-level clock frequency scaling, tracked separately), but both are real, independent bugs/hardening worth fixing regardless.

## Test plan
- [x] Clean Release build on macOS (Xcode/arm64+x86_64 universal), `jucePluginLib` target
- [ ] CI build across all platforms/synths