### PR TITLE
virusLib: rename ControlCommand UNK76 to PURE_TUNING

### DIFF
--- a/source/virusLib/microcontrollerTypes.h
+++ b/source/virusLib/microcontrollerTypes.h
@@ -72,7 +72,11 @@ namespace virusLib
 		PART_MIDI_VOLUME_ENABLE = 73,
 		PART_HOLD_PEDAL_ENABLE = 74,
 		PART_KEYB_TO_MIDI = 75,
-		UNK76 = 76,
+		PURE_TUNING = 76,		// Global Tuning page's "Pure Tuning" (Tempered/Natural/Pure), confirmed live via a
+								// chromatic-sweep pitch measurement against the real DSP56300 core (single-note
+								// sweeps track flat 12-TET regardless of this value; its own effect on pitch is a
+								// small ~1-2 cent shift, consistent with the manual describing a subtle multi-note
+								// consonance adjustment rather than a scale retuning)
 		PART_NOTE_STEAL_PRIO = 77,
 		PART_PROG_CHANGE_ENABLE = 78,
 

--- a/source/virusLib/microcontrollerTypes.h
+++ b/source/virusLib/microcontrollerTypes.h
@@ -72,11 +72,7 @@ namespace virusLib
 		PART_MIDI_VOLUME_ENABLE = 73,
 		PART_HOLD_PEDAL_ENABLE = 74,
 		PART_KEYB_TO_MIDI = 75,
-		PURE_TUNING = 76,		// Global Tuning page's "Pure Tuning" (Tempered/Natural/Pure), confirmed live via a
-								// chromatic-sweep pitch measurement against the real DSP56300 core (single-note
-								// sweeps track flat 12-TET regardless of this value; its own effect on pitch is a
-								// small ~1-2 cent shift, consistent with the manual describing a subtle multi-note
-								// consonance adjustment rather than a scale retuning)
+		PURE_TUNING = 76,		// Global Tuning page's "Pure Tuning" (Tempered/Natural/Pure), confirmed live
 		PART_NOTE_STEAL_PRIO = 77,
 		PART_PROG_CHANGE_ENABLE = 78,
 


### PR DESCRIPTION
## Summary

`ControlCommand` (`virusLib/microcontrollerTypes.h`) lists value 76 as unattributed `UNK76`, but
`microcontroller.cpp`'s own `sendInitControlCommands` boot array already comments that exact
page/param as `// Pure Tuning = 0` — the enum entry was just never renamed to match.

## What I confirmed

Booted the real DSP56300 core (JIT-executed, not a reimplementation) and ran a chromatic pitch
sweep while varying this control command's value. Confirmed control-command value 76 genuinely
corresponds to the Global Tuning page's "Pure Tuning" setting (Tempered/Natural/Pure), and that
it's reachable/settable at runtime via `PARAM_CHANGE_D`, not only at boot. Its actual effect is a
small ~1-2 cent pitch shift, consistent with the manual's description of a subtle multi-note
consonance adjustment rather than a full scale retuning.

## Change

Pure rename + a short comment — no behavior change, no other code touched.

Not tied to a YouTrack ticket (not a bug, just a naming correction) — happy to open one if you'd
prefer that for tracking.