### PR TITLE
virusLib: rename ControlCommand UNK6d to DSP_CLOCK_ADJUSTMENT

### DIFF
--- a/source/virusLib/microcontrollerTypes.h
+++ b/source/virusLib/microcontrollerTypes.h
@@ -85,7 +85,7 @@ namespace virusLib
 		MIDI_ARPEGGIATOR_SEND = 96,
 		MULTI_PROGRAM_CHANGE = 105,
 		MIDI_CLOCK_RX = 106,
-		UNK6d = 109,
+		DSP_CLOCK_ADJUSTMENT = 109,		// DSP PLL clock trim in percent (100=$64 default, 121=$79 max), confirmed live
 		DELAY_REVERB_MODE = 112,
 		EFFECT_SEND = 113,
 		DELAY_TIME = 114,


### PR DESCRIPTION
## Summary

`ControlCommand` (`virusLib/microcontrollerTypes.h`) lists value 109 as unattributed `UNK6d`, but
`microcontroller.cpp`'s own `sendInitControlCommands` boot array already comments that exact
page/param as `// DSP clock adjustment in percent (roughly), default $64 = 100%, max $79 = 121%`
— the enum entry was just never renamed to match.

## What I confirmed

Sent this control command live via `PARAM_CHANGE_D` (page `$73`, idx 109) against the real
DSP56300 core (JIT-executed) and watched the DSP's own PLL clock-control registers. It
live-reprograms the DSP's clock immediately, with an exact relationship more precise than the
firmware's own "roughly" hedge:

| Value sent | PLL MF register | Resulting clock |
|---|---|---|
| 100 (`$64`, documented default) | `0x8e` | 133.594 MHz |
| 110 | `0x98` | 143.002 MHz |
| 121 (`$79`, documented max) | `0xa3` | 153.35 MHz |

`mf = value + 42` exactly across all three tested points.

**Negative control**: sent the same value (121) to the neighboring unnamed index 108 instead —
it triggered the same generic clock-recompute log line, but left the clock at its unchanged
default. This rules out a coincidental "any PAGE_D write near here recomputes the clock" false
positive; the effect is specific to index 109's value.

## Change

Pure rename + a short comment — no behavior change, no other code touched. Unrelated to #279
(different enum value, different finding) — kept as a separate PR for independent review.

Not tied to a YouTrack ticket (not a bug, just a naming correction) — happy to open one if you'd
prefer that for tracking.