### PR TITLE
Feature: Add the ability for skins to hook into a per-frame DOM event

### DIFF
--- a/doc/lua_scripting.md
+++ b/doc/lua_scripting.md
@@ -31,6 +31,7 @@ Add a `<script>` block in your RML file's `<head>` section:
 - Use `onload="myFunction()"` on `<body>` to run code after all elements are created but before layout is computed.
 - Use `onshow="myFunction()"` on an element to run code when that element becomes visible. Layout is computed at this point, so `offset_width`/`offset_height` return correct values.
 - Inline event handlers like `onclick="..."` receive `event`, `element`, and `document` as parameters.
+- Use `onframe="myFunction(event)"` on `<body>` to run code before every rendered frame, after the document is loaded and laid out. See [Per-Frame Updates](#per-frame-updates-onframe).
 
 ### Globals
 
@@ -115,6 +116,27 @@ local part = params.getCurrentPart()
 local id = params.onPartChanged(function(newPart)
   -- newPart: 0-based part number
 end)
+```
+
+## Per-Frame Updates (`onframe`)
+
+A per-frame handler may be added to `<body>` to implement looping animations beyond the capabilities of
+RCSS `@keyframes` and `transition` (e.g. oscilliscopes).
+
+```html
+<body onframe="myFrameHandler(event)" ...>
+```
+
+```lua
+function myFrameHandler(event)
+
+  -- Do stuff every frame
+  myCanvas:repaint()
+
+  -- Determine the number of seconds since the previous frame
+  local elapsedTime = event.parameters['dt']
+
+end
 ```
 
 ## DOM Manipulation

--- a/source/framework/juce/juceRmlUi/juceRmlComponent.cpp
+++ b/source/framework/juce/juceRmlUi/juceRmlComponent.cpp
@@ -882,6 +882,8 @@ namespace juceRmlUi
 
 			evPreUpdate(this);
 
+			dispatchFrameEvent();
+
 			m_rmlContext->Update();
 
 			if (visible)
@@ -960,6 +962,29 @@ namespace juceRmlUi
 		std::scoped_lock lock(m_timerMutex);
 		// we make the timer run a bit faster to prevent that we miss the next frame time by a too large margin
 		startNextFrameTimer();
+	}
+
+	// Sends a "frame" event to the document before every context update, carrying the elapsed seconds
+	// since the previous one as "dt". A document opts in by declaring an onframe handler, which also keeps
+	// the frame loop awake. Documents without one are untouched and the loop keeps idling as before.
+	void RmlComponent::dispatchFrameEvent()
+	{
+		auto* doc = getDocument();
+
+		if (!doc || !doc->HasAttribute("onframe"))
+			return;
+
+		const auto t = m_rmlInterfaces.getSystemInterface().GetElapsedTime();
+
+		if (m_frameEventTime <= 0)
+			m_frameEventTime = t;
+
+		const auto dt = static_cast<float>(t - m_frameEventTime);
+		m_frameEventTime = t;
+
+		doc->DispatchEvent("frame", Rml::Dictionary{{"dt", Rml::Variant(dt)}}, false);
+
+		enqueueUpdate();
 	}
 
 	void RmlComponent::enqueueUpdate()

--- a/source/framework/juce/juceRmlUi/juceRmlComponent.h
+++ b/source/framework/juce/juceRmlUi/juceRmlComponent.h
@@ -151,6 +151,7 @@ namespace juceRmlUi
 
 	private:
 		void update();
+		void dispatchFrameEvent();
 		void createRmlContext(const ContextCreatedCallback& _contextCreatedCallback);
 		void destroyRmlContext();
 		void updateRmlContextDimensions();
@@ -203,6 +204,7 @@ namespace juceRmlUi
 		JUCE_DECLARE_NON_MOVEABLE(RmlComponent)
 
 		double m_time = 0;
+		double m_frameEventTime = 0;
 		float m_fps = 0;
 		float m_targetFPS = 0;
 


### PR DESCRIPTION
**Motivation**

Skins can animate declaratively with RCSS `transition` and `@keyframes`, but there is no way to run script on a frame boundary. Anything whose content must be computed each frame — an oscilloscope, a meter with its own ballistics — has no supported mechanism.

**Change**

`RmlComponent` dispatches a frame event to the document before each context update, carrying the elapsed seconds since the previous frame as `dt`:

```
<body onframe="onFrame(event) ...">

function onFrame(event)
  elapsedTime = elapsedTime + event.parameters['dt']
  scopeCanvas:repaint()
end
```

It is dispatched right after `evPreUpdate`, so a `repaint()` from the handler is drawn in the same frame.

**Opt-in and backwards compatibility**

The `onframe` attribute is the opt-in. A document without one gets no dispatch, no `enqueueUpdate()`, and the renderer keeps idling at 2 Hz exactly as before — existing skins are unaffected and pay nothing.

**Consistency and safety**

Consumed exactly like `onclick` / `onshow` / `ontransitionend`, so it needs no new concepts and no new global. Inline handlers are compiled into Lua event listeners invoked through `Interpreter::ExecuteCall`, so the existing 3-second `LUA_MASKCOUNT` script timeout and traceback already cover a runaway frame handler — no special handling added.

**Notes**

- The event is dispatched on the document and does not bubble, so the handler must be on `<body>`. Attaching one via `AddEventListener("frame", ...)` alone will not enable it, as the attribute gates dispatch.
- Frame intervals are not uniform; handlers should advance animation by dt rather than assume a fixed step. Documented.

**AI Disclosure**

This PR was made with the help of an AI coding assistant.