### PR TITLE
Add per-parameter MIDI input suppression

### DIFF
--- a/source/framework/juce/jucePluginData/tus_settings_midilearn.rcss
+++ b/source/framework/juce/jucePluginData/tus_settings_midilearn.rcss
@@ -28,11 +28,15 @@
 	padding-bottom: 0.3em;
 }
 
-.ml-col-type { width: 7%; }
+#mappingTable {
+	column-gap: 0.65em;
+}
+
 .ml-col-channel { width: 8%; }
 .ml-col-part { width: 8%; }
 .ml-col-controller { width: 9%; }
 .ml-col-mode { width: 17%; }
 .ml-col-invert { width: 7%; }
-.ml-col-parameter { width: 19%; }
-.ml-col-remove { width: 15%; }
+.ml-col-disabled { width: 10%; }
+.ml-col-parameter { width: 23%; }
+.ml-col-remove { width: 8%; }

--- a/source/framework/juce/jucePluginData/tus_settings_midilearn.rml
+++ b/source/framework/juce/jucePluginData/tus_settings_midilearn.rml
@@ -25,17 +25,16 @@
 		
 		<table class="settings-table" id="mappingTable" style="padding-top: 0.5em; padding-bottom: 1em;">
 			<tr class="settings-tr settings-tr-headline">
-				<td class="ml-col-type">Type</td>
 				<td class="ml-col-channel">Channel</td>
 				<td class="ml-col-part">Part</td>
 				<td class="ml-col-controller">Controller</td>
 				<td class="ml-col-mode">Mode</td>
 				<td class="ml-col-invert">Invert</td>
+				<td class="ml-col-disabled">Disabled</td>
 				<td class="ml-col-parameter">Parameter</td>
-				<td class="ml-col-remove"></td>
+				<td class="ml-col-remove">Remove</td>
 			</tr>
 			<tr id="mappingRow" class="settings-tr ml-tr">
-				<td id="type" class="ml-col-type">CC</td>
 				<td class="ml-col-channel">
 					<combo id="channelCombo" class="settings-combo-small settings-combo-channel">
 						<combotext>All</combotext>
@@ -55,8 +54,11 @@
 				<td class="ml-col-invert">
 					<button id="cbInvert" class="settings-checkbox"/>
 				</td>
+				<td class="ml-col-disabled">
+					<button id="cbMidiControl" class="settings-checkbox" title="When checked, matching MIDI messages do not change the parameter or reach the synth firmware."/>
+				</td>
 				<td id="parameter" class="ml-col-parameter">Filter Cutoff</td>
-				<td class="ml-col-remove"><button id="btRemove" class="button">Remove</button></td>
+				<td class="ml-col-remove"><button id="btRemove" class="button" title="Remove">×</button></td>
 			</tr>
 		</table>
 		

--- a/source/framework/juce/jucePluginEditorLib/pluginEditor.cpp
+++ b/source/framework/juce/jucePluginEditorLib/pluginEditor.cpp
@@ -661,7 +661,57 @@ namespace jucePluginEditorLib
 			{
 				const auto& preset = translator->getPreset();
 				const auto mappings = preset.findMappingsByParam(param->getDescription().name);
-				if (!mappings.empty())
+				const auto paramPart = param->getPart();
+				const auto appliesToPart = [paramPart](const pluginLib::MidiLearnMapping* _mapping)
+				{
+					return _mapping->part == pluginLib::MidiLearnMapping::AutoPart ||
+						_mapping->part == paramPart;
+				};
+
+				const bool hasApplicableMappings = std::any_of(mappings.begin(), mappings.end(), appliesToPart);
+				const bool ignoreMidiEvents = preset.isInputBlocked(param->getDescription().name, paramPart);
+
+				const auto midiControlAction = ignoreMidiEvents ? "Enable MIDI Control" : "Disable MIDI Control";
+				menu.addEntry(midiControlAction, [this, param, ignoreMidiEvents]()
+				{
+					auto* t = m_processor.getMidiLearnTranslator();
+					if (!t) return;
+
+					auto updatedPreset = t->getPreset();
+					const auto paramName = param->getDescription().name;
+					const auto currentPart = param->getPart();
+					if (ignoreMidiEvents)
+					{
+						auto& blocks = updatedPreset.getInputBlocks();
+						blocks.erase(std::remove_if(blocks.begin(), blocks.end(), [&](const pluginLib::MidiInputBlock& _block)
+						{
+							return _block.paramName == paramName &&
+								(_block.part == pluginLib::MidiLearnMapping::AutoPart || _block.part == currentPart);
+						}), blocks.end());
+					}
+					else
+					{
+						const auto learnedMappings = updatedPreset.findMappingsByParam(paramName);
+						bool addedForMapping = false;
+						for (const auto* mapping : learnedMappings)
+						{
+							if (mapping->part == pluginLib::MidiLearnMapping::AutoPart || mapping->part == currentPart)
+							{
+								updatedPreset.addInputBlock({paramName, mapping->part});
+								addedForMapping = true;
+							}
+						}
+						if (!addedForMapping)
+							updatedPreset.addInputBlock({paramName, currentPart});
+					}
+
+					t->setPreset(updatedPreset);
+					if (m_overlays)
+						m_overlays->refreshMidiLearnOverlays();
+					m_processor.saveDefaultMidiLearnPreset();
+				});
+
+				if (hasApplicableMappings)
 				{
 					menu.addEntry("Clear MIDI Mapping", [this, param]()
 					{
@@ -683,6 +733,7 @@ namespace jucePluginEditorLib
 						t->setPreset(preset);
 						if (m_overlays)
 							m_overlays->refreshMidiLearnOverlays();
+						m_processor.saveDefaultMidiLearnPreset();
 					});
 				}
 			}

--- a/source/framework/juce/jucePluginEditorLib/settingsMidiLearn.cpp
+++ b/source/framework/juce/jucePluginEditorLib/settingsMidiLearn.cpp
@@ -272,15 +272,20 @@ namespace jucePluginEditorLib
 		if (_mappingIndex >= preset.getMappings().size())
 			return;
 
+		const bool editingCurrentPreset = isCurrentPresetSelected();
 		preset.removeMapping(_mappingIndex);
 		
-		// Save the preset
+		// "Current" is persisted via the internal default preset; named presets
+		// continue to be saved under their own names.
 		const juce::String presetName(preset.getName());
-		if (m_learnManager.savePreset(presetName, preset))
+		if (editingCurrentPreset || m_learnManager.savePreset(presetName, preset))
 		{
 			translator->setPreset(preset); // Refresh subscriptions
-			if (isCurrentPresetSelected())
+			if (editingCurrentPreset)
+			{
 				m_originalPreset = preset;
+				m_processor.saveDefaultMidiLearnPreset();
+			}
 			refreshMappingList();
 			refreshFeedbackCheckboxes();
 		}
@@ -398,6 +403,44 @@ namespace jucePluginEditorLib
 				m_processor.getProductName(),
 				"Failed to save invert change.");
 		}
+	}
+
+	void SettingsMidiLearn::onMidiControlToggled(const std::string& _paramName, uint8_t _part, bool _enabled)
+	{
+		auto* translator = m_processor.getMidiLearnTranslator();
+		if (!translator)
+			return;
+
+		auto& preset = const_cast<pluginLib::MidiLearnPreset&>(translator->getPreset());
+		const bool editingCurrentPreset = isCurrentPresetSelected();
+		const juce::String presetName(preset.getName());
+		if (_enabled)
+			preset.removeInputBlock(_paramName, _part);
+		else
+			preset.addInputBlock({_paramName, _part});
+
+		if (editingCurrentPreset || m_learnManager.savePreset(presetName, preset))
+		{
+			translator->setPreset(preset);
+			if (editingCurrentPreset)
+			{
+				m_originalPreset = preset;
+				m_processor.saveDefaultMidiLearnPreset();
+			}
+			refreshMappingList();
+		}
+		else
+		{
+			genericUI::MessageBox::showOk(
+				genericUI::MessageBox::Icon::Warning,
+				m_processor.getProductName(),
+				"Failed to save MIDI control change.");
+		}
+	}
+
+	void SettingsMidiLearn::onBtRemoveInputBlock(const std::string& _paramName, uint8_t _part)
+	{
+		onMidiControlToggled(_paramName, _part, true);
 	}
 
 	void SettingsMidiLearn::onPartChanged(size_t _mappingIndex, int _newPartIndex)
@@ -523,24 +566,9 @@ namespace jucePluginEditorLib
 			auto* row = m_mappingTableBody->AppendChild(m_mappingRowTemplate->Clone());
 
 			// Fill in the mapping data
-			auto* typeCell = juceRmlUi::helper::findChild(row, "type");
 			auto* controllerCell = juceRmlUi::helper::findChild(row, "controller");
 			auto* parameterCell = juceRmlUi::helper::findChild(row, "parameter");
 			auto* removeButton = juceRmlUi::helper::findChild(row, "btRemove");
-
-			if (typeCell)
-			{
-				std::string typeStr;
-				switch (mapping.type)
-				{
-				case pluginLib::MidiLearnMapping::Type::ControlChange: typeStr = "CC"; break;
-				case pluginLib::MidiLearnMapping::Type::PolyPressure: typeStr = "Poly Press"; break;
-				case pluginLib::MidiLearnMapping::Type::ChannelPressure: typeStr = "Chan Press"; break;
-				case pluginLib::MidiLearnMapping::Type::PitchBend: typeStr = "Pitch Bend"; break;
-				case pluginLib::MidiLearnMapping::Type::NRPN: typeStr = "NRPN"; break;
-				}
-				typeCell->SetInnerRML(typeStr);
-			}
 
 			// Create and populate channel combo box
 			if (auto* channelCombo = juceRmlUi::helper::findChildT<juceRmlUi::ElemComboBox>(row, "channelCombo"))
@@ -606,6 +634,18 @@ namespace jucePluginEditorLib
 				});
 			}
 
+			// MIDI Disabled checkbox
+			if (auto* cbMidiControl = juceRmlUi::helper::findChildT<juceRmlUi::ElemButton>(row, "cbMidiControl"))
+			{
+				const bool inputBlocked = translator->getPreset().isInputBlocked(mapping.paramName, mapping.part);
+				cbMidiControl->setChecked(inputBlocked);
+				juceRmlUi::EventListener::Add(cbMidiControl, Rml::EventId::Click, [this, paramName = mapping.paramName, part = mapping.part, inputBlocked](Rml::Event& _event)
+				{
+					_event.StopPropagation();
+					onMidiControlToggled(paramName, part, inputBlocked);
+				});
+			}
+
 			// Create and populate part combo box
 			if (auto* partCombo = juceRmlUi::helper::findChildT<juceRmlUi::ElemComboBox>(row, "partCombo"))
 			{
@@ -635,6 +675,53 @@ namespace jucePluginEditorLib
 				{
 					_event.StopPropagation();
 					onBtRemoveMapping(i);
+				});
+			}
+		}
+
+		const auto& blocks = translator->getPreset().getInputBlocks();
+		for (const auto& block : blocks)
+		{
+			const bool hasMapping = std::any_of(mappings.begin(), mappings.end(), [&](const pluginLib::MidiLearnMapping& _mapping)
+			{
+				return _mapping.paramName == block.paramName &&
+					(block.part == pluginLib::MidiLearnMapping::AutoPart || _mapping.part == block.part);
+			});
+			if (hasMapping)
+				continue;
+
+			auto* row = m_mappingTableBody->AppendChild(m_mappingRowTemplate->Clone());
+			if (auto* cell = juceRmlUi::helper::findChild(row, "controller")) cell->SetInnerRML("Default");
+			if (auto* cell = juceRmlUi::helper::findChild(row, "parameter")) cell->SetInnerRML(block.paramName);
+
+			if (auto* combo = juceRmlUi::helper::findChild(row, "channelCombo")) combo->GetParentNode()->SetInnerRML("All");
+			if (auto* combo = juceRmlUi::helper::findChild(row, "modeCombo")) combo->GetParentNode()->SetInnerRML("-");
+			if (auto* invert = juceRmlUi::helper::findChild(row, "cbInvert")) invert->GetParentNode()->SetInnerRML("-");
+
+			if (auto* partCombo = juceRmlUi::helper::findChildT<juceRmlUi::ElemComboBox>(row, "partCombo"))
+			{
+				partCombo->addOption("Auto");
+				for (uint8_t p = 0; p < m_processor.getController().getPartCount(); ++p)
+					partCombo->addOption(std::to_string(p + 1));
+				partCombo->setSelectedIndex(block.part == pluginLib::MidiLearnMapping::AutoPart ? 0 : block.part + 1, false);
+			}
+
+			if (auto* cb = juceRmlUi::helper::findChildT<juceRmlUi::ElemButton>(row, "cbMidiControl"))
+			{
+				cb->setChecked(true);
+				juceRmlUi::EventListener::Add(cb, Rml::EventId::Click, [this, paramName = block.paramName, part = block.part](Rml::Event& _event)
+				{
+					_event.StopPropagation();
+					onMidiControlToggled(paramName, part, true);
+				});
+			}
+
+			if (auto* remove = juceRmlUi::helper::findChild(row, "btRemove"))
+			{
+				juceRmlUi::EventListener::Add(remove, Rml::EventId::Click, [this, paramName = block.paramName, part = block.part](Rml::Event& _event)
+				{
+					_event.StopPropagation();
+					onBtRemoveInputBlock(paramName, part);
 				});
 			}
 		}

--- a/source/framework/juce/jucePluginEditorLib/settingsMidiLearn.h
+++ b/source/framework/juce/jucePluginEditorLib/settingsMidiLearn.h
@@ -34,6 +34,8 @@ namespace jucePluginEditorLib
 		void onChannelChanged(size_t _mappingIndex, int _newChannelIndex);
 		void onPartChanged(size_t _mappingIndex, int _newPartIndex);
 		void onInvertToggled(size_t _mappingIndex, bool _invert);
+		void onMidiControlToggled(const std::string& _paramName, uint8_t _part, bool _enabled);
+		void onBtRemoveInputBlock(const std::string& _paramName, uint8_t _part);
 		void onInputSourceToggle(synthLib::MidiEventSource _source) const;
 		void onFeedbackTargetToggle(synthLib::MidiEventSource _target);
 

--- a/source/framework/juce/jucePluginLib/midiLearnMapping.cpp
+++ b/source/framework/juce/jucePluginLib/midiLearnMapping.cpp
@@ -114,17 +114,19 @@ namespace pluginLib
 	{
 		switch (_type)
 		{
+		case Type::Invalid: return "Invalid";
 		case Type::ControlChange: return "ControlChange";
 		case Type::PolyPressure: return "PolyPressure";
 		case Type::ChannelPressure: return "ChannelPressure";
 		case Type::PitchBend: return "PitchBend";
 		case Type::NRPN: return "NRPN";
-		default: return "ControlChange";
+		default: return "Invalid";
 		}
 	}
 
 	MidiLearnMapping::Type MidiLearnMapping::stringToType(const std::string& _str)
 	{
+		if (_str == "Invalid") return Type::Invalid;
 		if (_str == "ControlChange") return Type::ControlChange;
 		if (_str == "PolyPressure") return Type::PolyPressure;
 		if (_str == "ChannelPressure") return Type::ChannelPressure;

--- a/source/framework/juce/jucePluginLib/midiLearnPreset.cpp
+++ b/source/framework/juce/jucePluginLib/midiLearnPreset.cpp
@@ -3,6 +3,7 @@
 #include "synthLib/midiTypes.h"
 
 #include <juce_core/juce_core.h>
+#include <algorithm>
 
 namespace pluginLib
 {
@@ -25,6 +26,42 @@ namespace pluginLib
 	void MidiLearnPreset::clearMappings()
 	{
 		m_mappings.clear();
+	}
+
+	void MidiLearnPreset::addInputBlock(const MidiInputBlock& _block)
+	{
+		if (_block.part == MidiLearnMapping::AutoPart)
+		{
+			m_inputBlocks.erase(std::remove_if(m_inputBlocks.begin(), m_inputBlocks.end(), [&](const MidiInputBlock& _existing)
+			{
+				return _existing.paramName == _block.paramName;
+			}), m_inputBlocks.end());
+		}
+		else if (isInputBlocked(_block.paramName, _block.part))
+		{
+			return;
+		}
+
+		m_inputBlocks.push_back(_block);
+	}
+
+	void MidiLearnPreset::removeInputBlock(const std::string& _paramName, uint8_t _part)
+	{
+		m_inputBlocks.erase(std::remove_if(m_inputBlocks.begin(), m_inputBlocks.end(),
+			[&](const MidiInputBlock& _block)
+			{
+				return _block.paramName == _paramName &&
+					(_block.part == _part || _block.part == MidiLearnMapping::AutoPart);
+			}), m_inputBlocks.end());
+	}
+
+	bool MidiLearnPreset::isInputBlocked(const std::string& _paramName, uint8_t _part) const
+	{
+		return std::any_of(m_inputBlocks.begin(), m_inputBlocks.end(), [&](const MidiInputBlock& _block)
+		{
+			return _block.paramName == _paramName &&
+				(_block.part == MidiLearnMapping::AutoPart || _block.part == _part);
+		});
 	}
 
 	const MidiLearnMapping* MidiLearnPreset::findMapping(MidiLearnMapping::Type _type, uint8_t _channel, uint8_t _controller) const
@@ -71,6 +108,16 @@ namespace pluginLib
 			mappingsArray.add(mapping.toJson());
 		}
 		obj->setProperty("mappings", mappingsArray);
+
+		juce::Array<juce::var> inputBlocksArray;
+		for (const auto& block : m_inputBlocks)
+		{
+			auto* blockObj = new juce::DynamicObject();
+			blockObj->setProperty("paramName", juce::String(block.paramName));
+			blockObj->setProperty("part", static_cast<int>(block.part));
+			inputBlocksArray.add(juce::var(blockObj));
+		}
+		obj->setProperty("inputBlocks", inputBlocksArray);
 		obj->setProperty("defaultFeedbackTargets", static_cast<int>(m_defaultFeedbackTargets));
 
 		return juce::var(obj);
@@ -89,13 +136,39 @@ namespace pluginLib
 			return false; // Unsupported version
 
 		m_mappings.clear();
+		m_inputBlocks.clear();
 
 		const auto* mappingsArray = obj->getProperty("mappings").getArray();
 		if (mappingsArray)
 		{
 			for (const auto& mappingVar : *mappingsArray)
 			{
-				m_mappings.push_back(MidiLearnMapping::fromJson(mappingVar));
+				auto mapping = MidiLearnMapping::fromJson(mappingVar);
+				if (auto* mappingObj = mappingVar.getDynamicObject())
+				{
+					const bool discarded = mappingObj->hasProperty("discardInput") && static_cast<bool>(mappingObj->getProperty("discardInput"));
+					const bool firmwareDefault = mappingObj->hasProperty("defaultController") && static_cast<bool>(mappingObj->getProperty("defaultController"));
+					if (discarded)
+						addInputBlock({mapping.paramName, mapping.part});
+					if (firmwareDefault)
+						continue;
+				}
+				m_mappings.push_back(mapping);
+			}
+		}
+
+		if (const auto* inputBlocksArray = obj->getProperty("inputBlocks").getArray())
+		{
+			for (const auto& blockVar : *inputBlocksArray)
+			{
+				if (auto* blockObj = blockVar.getDynamicObject())
+				{
+					const auto paramName = blockObj->getProperty("paramName").toString().toStdString();
+					const auto part = blockObj->hasProperty("part")
+						? static_cast<uint8_t>(static_cast<int>(blockObj->getProperty("part")))
+						: MidiLearnMapping::AutoPart;
+					addInputBlock({paramName, part});
+				}
 			}
 		}
 
@@ -127,7 +200,7 @@ namespace pluginLib
 	bool MidiLearnPreset::operator==(const MidiLearnPreset& _other) const
 	{
 		// Compare mappings only, not names
-		if (m_mappings.size() != _other.m_mappings.size())
+		if (m_mappings.size() != _other.m_mappings.size() || m_inputBlocks != _other.m_inputBlocks)
 			return false;
 
 		for (size_t i = 0; i < m_mappings.size(); ++i)

--- a/source/framework/juce/jucePluginLib/midiLearnPreset.h
+++ b/source/framework/juce/jucePluginLib/midiLearnPreset.h
@@ -10,6 +10,17 @@ namespace synthLib { struct SMidiEvent; }
 
 namespace pluginLib
 {
+	struct MidiInputBlock
+	{
+		std::string paramName;
+		uint8_t part = MidiLearnMapping::AutoPart;
+
+		bool operator==(const MidiInputBlock& _other) const
+		{
+			return paramName == _other.paramName && part == _other.part;
+		}
+	};
+
 	class MidiLearnPreset
 	{
 	public:
@@ -26,6 +37,13 @@ namespace pluginLib
 		void clearMappings();
 		const std::vector<MidiLearnMapping>& getMappings() const { return m_mappings; }
 		std::vector<MidiLearnMapping>& getMappings() { return m_mappings; }
+
+		// Parameter-level MIDI suppression, independent of learned mappings.
+		void addInputBlock(const MidiInputBlock& _block);
+		void removeInputBlock(const std::string& _paramName, uint8_t _part);
+		bool isInputBlocked(const std::string& _paramName, uint8_t _part) const;
+		const std::vector<MidiInputBlock>& getInputBlocks() const { return m_inputBlocks; }
+		std::vector<MidiInputBlock>& getInputBlocks() { return m_inputBlocks; }
 
 		// Find mapping by MIDI message
 		const MidiLearnMapping* findMapping(MidiLearnMapping::Type _type, uint8_t _channel, uint8_t _controller) const;
@@ -46,7 +64,7 @@ namespace pluginLib
 		bool operator==(const MidiLearnPreset& _other) const;
 
 		// Returns true if preset is empty (no mappings and no name)
-		bool empty() const { return m_name.empty() && m_mappings.empty(); }
+		bool empty() const { return m_name.empty() && m_mappings.empty() && m_inputBlocks.empty(); }
 
 		// Default feedback targets applied to newly learned mappings
 		uint8_t getDefaultFeedbackTargets() const { return m_defaultFeedbackTargets; }
@@ -55,6 +73,7 @@ namespace pluginLib
 	private:
 		std::string m_name;
 		std::vector<MidiLearnMapping> m_mappings;
+		std::vector<MidiInputBlock> m_inputBlocks;
 		uint8_t m_defaultFeedbackTargets = 0;
 	};
 }

--- a/source/framework/juce/jucePluginLib/midiLearnTranslator.cpp
+++ b/source/framework/juce/jucePluginLib/midiLearnTranslator.cpp
@@ -6,6 +6,7 @@
 #include "baseLib/binarystream.h"
 
 #include <juce_data_structures/juce_data_structures.h>
+#include <algorithm>
 
 namespace pluginLib
 {
@@ -82,10 +83,14 @@ namespace pluginLib
 		const auto* mapping = m_preset.findMapping(_event);
 		if (mapping)
 		{
-			// Found a learned mapping - apply it and consume the event
-			applyMapping(*mapping, _event);
+			if (!isMappingInputBlocked(*mapping, _event))
+				applyMapping(*mapping, _event);
 			return true; // Consumed - don't forward to device
 		}
+
+		// A parameter can discard MIDI input without having a learned override
+		if (isBlockedDefaultControllerMapping(_event))
+			return true;
 
 		// No learned mapping found
 		// Check if this is a default controller mapping handled by firmware
@@ -119,6 +124,44 @@ namespace pluginLib
 		// Check if this MIDI event matches any default controller mapping
 		const auto& params = m_controllerMap.getParameters(_event);
 		return !params.empty();
+	}
+
+	bool MidiLearnTranslator::isMappingInputBlocked(const MidiLearnMapping& _mapping, const synthLib::SMidiEvent& _event) const
+	{
+		if (_mapping.part != MidiLearnMapping::AutoPart)
+			return m_preset.isInputBlocked(_mapping.paramName, _mapping.part);
+
+		const auto eventParts = m_controller.getPartsForMidiEvent(_event);
+		if (eventParts.empty())
+			return m_preset.isInputBlocked(_mapping.paramName, MidiLearnMapping::AutoPart);
+
+		return std::any_of(eventParts.begin(), eventParts.end(), [&](uint8_t _part)
+		{
+			return m_preset.isInputBlocked(_mapping.paramName, _part);
+		});
+	}
+
+	bool MidiLearnTranslator::isBlockedDefaultControllerMapping(const synthLib::SMidiEvent& _event) const
+	{
+		const auto& paramIndices = m_controllerMap.getParameters(_event);
+		if (paramIndices.empty())
+			return false;
+
+		const auto eventParts = m_controller.getPartsForMidiEvent(_event);
+
+		for (const auto& block : m_preset.getInputBlocks())
+		{
+			const auto paramIndex = m_controller.getParameterIndexByName(block.paramName);
+			if (paramIndex == Controller::InvalidParameterIndex ||
+				std::find(paramIndices.begin(), paramIndices.end(), paramIndex) == paramIndices.end())
+				continue;
+
+			if (block.part == MidiLearnMapping::AutoPart || eventParts.empty() ||
+				std::find(eventParts.begin(), eventParts.end(), block.part) != eventParts.end())
+				return true;
+		}
+
+		return false;
 	}
 
 	void MidiLearnTranslator::applyMapping(const MidiLearnMapping& _mapping, const synthLib::SMidiEvent& _event)
@@ -406,7 +449,8 @@ namespace pluginLib
 		
 		for (const auto* mapping : mappings)
 		{
-			if (!mapping || mapping->feedbackTargets == 0)
+			if (!mapping || mapping->type == MidiLearnMapping::Type::Invalid ||
+				m_preset.isInputBlocked(mapping->paramName, mapping->part) || mapping->feedbackTargets == 0)
 				continue;
 
 			// Create the feedback MIDI event
@@ -449,6 +493,10 @@ namespace pluginLib
 
 		switch (_mapping.type)
 		{
+		case MidiLearnMapping::Type::Invalid:
+			// Invalid mappings cannot produce meaningful MIDI feedback.
+			break;
+
 		case MidiLearnMapping::Type::ControlChange:
 		case MidiLearnMapping::Type::PolyPressure:
 			event.b = _mapping.controller;

--- a/source/framework/juce/jucePluginLib/midiLearnTranslator.h
+++ b/source/framework/juce/jucePluginLib/midiLearnTranslator.h
@@ -56,6 +56,8 @@ namespace pluginLib
 
 	private:
 		bool isDefaultControllerMapping(const synthLib::SMidiEvent& _event) const;
+		bool isBlockedDefaultControllerMapping(const synthLib::SMidiEvent& _event) const;
+		bool isMappingInputBlocked(const MidiLearnMapping& _mapping, const synthLib::SMidiEvent& _event) const;
 		void applyMapping(const MidiLearnMapping& _mapping, const synthLib::SMidiEvent& _event);
 		void applyMappingToParam(const MidiLearnMapping& _mapping, const synthLib::SMidiEvent& _event, Parameter& _param);
 		void handleLearning(const synthLib::SMidiEvent& _event);

--- a/source/framework/tools/midiLearnTest/midiLearnTest.cpp
+++ b/source/framework/tools/midiLearnTest/midiLearnTest.cpp
@@ -800,6 +800,72 @@ void testMidiLearnInvert()
 	std::cout << "  Invert flag tests passed!" << std::endl;
 }
 
+void testMidiInputBlocks()
+{
+	std::cout << "Testing independent MIDI input blocks..." << std::endl;
+
+	MidiLearnMapping mapping;
+	mapping.type = MidiLearnMapping::Type::ControlChange;
+	mapping.channel = 0;
+	mapping.controller = 74;
+	mapping.paramName = "Filter Cutoff";
+
+	MidiLearnPreset normalPreset("Normal");
+	normalPreset.addMapping(mapping);
+
+	MidiLearnPreset blockedPreset("Blocked");
+	blockedPreset.addMapping(mapping);
+	blockedPreset.addInputBlock({"Filter Cutoff", 0});
+	TEST_ASSERT(blockedPreset.isInputBlocked("Filter Cutoff", 0));
+	TEST_ASSERT(!blockedPreset.isInputBlocked("Filter Cutoff", 1));
+	TEST_ASSERT(!(normalPreset == blockedPreset));
+
+	auto presetJson = blockedPreset.toJson();
+	MidiLearnPreset restoredPreset;
+	TEST_ASSERT(restoredPreset.fromJson(presetJson));
+	TEST_ASSERT(restoredPreset.getMappings().size() == 1);
+	TEST_ASSERT(restoredPreset.getInputBlocks().size() == 1);
+	TEST_ASSERT(restoredPreset.isInputBlocked("Filter Cutoff", 0));
+
+	// Clearing a learned mapping must not clear the independent input block.
+	restoredPreset.clearMappings();
+	TEST_ASSERT(restoredPreset.getMappings().empty());
+	TEST_ASSERT(restoredPreset.isInputBlocked("Filter Cutoff", 0));
+	restoredPreset.removeInputBlock("Filter Cutoff", 0);
+	TEST_ASSERT(restoredPreset.getInputBlocks().empty());
+
+	// Migrate presets written by the earlier placeholder-mapping implementation.
+	auto legacyJson = normalPreset.toJson();
+	if (auto* root = legacyJson.getDynamicObject())
+	{
+		root->removeProperty("inputBlocks");
+		if (auto* mappings = root->getProperty("mappings").getArray())
+		{
+			if (auto* mappingObj = (*mappings)[0].getDynamicObject())
+				mappingObj->setProperty("discardInput", true);
+
+			auto placeholder = mapping.toJson();
+			if (auto* placeholderObj = placeholder.getDynamicObject())
+			{
+				placeholderObj->setProperty("type", "Invalid");
+				placeholderObj->setProperty("paramName", "Oscillator Shape");
+				placeholderObj->setProperty("discardInput", true);
+				placeholderObj->setProperty("defaultController", true);
+			}
+			mappings->add(placeholder);
+		}
+	}
+
+	MidiLearnPreset migrated;
+	TEST_ASSERT(migrated.fromJson(legacyJson));
+	TEST_ASSERT(migrated.getMappings().size() == 1);
+	TEST_ASSERT(migrated.getInputBlocks().size() == 2);
+	TEST_ASSERT(migrated.isInputBlocked("Filter Cutoff", MidiLearnMapping::AutoPart));
+	TEST_ASSERT(migrated.isInputBlocked("Oscillator Shape", MidiLearnMapping::AutoPart));
+
+	std::cout << "  MIDI input block tests passed!" << std::endl;
+}
+
 void testMidiLearnMixedTypes()
 {
 	std::cout << "Testing MIDI Learn Mixed Types preset..." << std::endl;
@@ -907,6 +973,7 @@ int main()
 		testMidiLearnChannelPressure();
 		testMidiLearnPolyPressure();
 		testMidiLearnInvert();
+		testMidiInputBlocks();
 		testMidiLearnMixedTypes();
 
 		std::cout << std::endl;


### PR DESCRIPTION
This is a result of repeated questions in Discord about MIDI controls falling through to their default mappings.

We can't alter the firmware; however, if we simply refuse to forward those MIDI events, I believe we can satisfy the actual user need.

This adds a per-parameter `Disable MIDI Control` option to the existing context menu and uses the existing MIDI mapping machinery to discard matching input.

Once toggled, MIDI events are discarded, and the context menu label is changed to `Enable MIDI Control`.

An entry is also added to the `Mappings` table in Settings. Unchecking `Disabled` for a parameter that does not have a learned MIDI control will remove the entry from the table, since it no longer has a mapping or suppression state to display.

Style changes were also made to the `Mappings` table to prevent the `Remove` button from running off the page.

**Review note**: MIDI mapping type serialization
(source/framework/juce/jucePluginLib/midiLearnMapping.cpp:117-123)

This also changes MIDI mapping type serialization so that `Type::Invalid` is represented as `Invalid`, rather than falling back to `ControlChange`. This is used for suppression-only entries that do not have a learned MIDI control. Unknown types now also fall back to `Invalid`.

On the surface, this appears to be more correct and an improvement, but it is unknown if any legacy code depends on the existing behavior. This specific change deserves careful consideration during review.

Tested on Apple Silicon, macOS 15.7.4, Live 12.4.3