### PR TITLE
h8s: skip timer cycles where nothing can happen

### DIFF
--- a/source/cpu/h8s/h8s.hpp
+++ b/source/cpu/h8s/h8s.hpp
@@ -51,6 +51,11 @@ public:
 	uint8 exr {0};
 	H8SDevice* maps[1<<24] {};
 	unsigned long long  cycles {0};
+	/* `cycles` as it stood when the current instruction began. Devices that
+	 * defer their per-instruction tick (Timers) catch up to THIS on a register
+	 * access, which is the state the original end-of-previous-instruction tick
+	 * would have left them in. */
+	unsigned long long instrStartCycles {0};
 	unsigned long long pending_irqs {0};
 	
 	enum
@@ -273,6 +278,7 @@ public:
 	uint8 *handle_instr(uint8 *_pc)
 	{
 		pc = _pc;
+		instrStartCycles = cycles;
 		if (execute && pending_irqs)
 		{
 			bool ue = read8(0xfffff2) & 8;

--- a/source/cpu/h8s/h8sdevices.hpp
+++ b/source/cpu/h8s/h8sdevices.hpp
@@ -20,7 +20,18 @@ public:
 	void tick_extclock(int which) {
 		channels[which].gra++;
 	}
+	/* Called once per H8S instruction. Nothing observable happens between
+	 * events (a channel reaching gra, grb or 0), and `nextEvent` is the first
+	 * cycle at which one can, so until then this is one compare. The deferred
+	 * increments are the same as the per-instruction ones because inc is a
+	 * difference of floors, which is additive across any split. Register
+	 * accesses catch up first (`catchUp`), so the H8S never sees a stale tcnt. */
 	void tick()
+	{
+		if (state->cycles < nextEvent) return;
+		update(state->cycles);
+	}
+	void update(unsigned long long now)
 	{
 		for (int i = 0; i < 5; i++)
 		{
@@ -29,9 +40,21 @@ public:
 			class channel& c = channels[i];
 			if (c.tcr & 4) continue;			// skip externally clocked channels
 			int shift = (c.tcr & 3);
-			unsigned int inc = (unsigned int)((state->cycles >> shift) - (lastCycles >> shift));	// how many cycles have passed?
-			for (int j = 0; j < inc; j++)
+			unsigned int inc = (unsigned int)((now >> shift) - (lastCycles >> shift));	// how many cycles have passed?
+			/* Per-cycle stepping, but only the cycles that START on an event
+			 * (tcnt == gra, == grb or == 0) do anything besides tcnt++, so jump
+			 * straight to the next one. Same tsr bits, interrupts and final
+			 * tcnt as stepping every cycle; this used to loop ~180 times per
+			 * sample per channel. */
+			while (inc)
 			{
+				unsigned int d = (uint16)(c.gra - c.tcnt);
+				const unsigned int db = (uint16)(c.grb - c.tcnt), dz = (uint16)(0 - c.tcnt);
+				if (db < d) d = db;
+				if (dz < d) d = dz;
+				if (d >= inc) { c.tcnt += inc; break; }
+				c.tcnt += d;
+				inc -= d + 1;
 				uint16 nt = c.tcnt + 1;
 				if (c.tcnt == c.gra)
 				{
@@ -53,10 +76,36 @@ public:
 				c.tcnt = nt;
 			}
 		}
-		lastCycles = state->cycles;
+		lastCycles = now;
+
+		/* Next cycle at which any running channel's tcnt reaches an event:
+		 * the loop above fires when inc >= d + 1 for that channel's shift. */
+		unsigned long long next = ~0ULL;
+		for (int i = 0; i < 5; i++)
+		{
+			if (!(tstr & (1 << i))) continue;
+			if (tmdr & (1 << i)) continue;
+			const class channel& c = channels[i];
+			if (c.tcr & 4) continue;
+			int shift = (c.tcr & 3);
+			unsigned int d = (uint16)(c.gra - c.tcnt);
+			const unsigned int db = (uint16)(c.grb - c.tcnt), dz = (uint16)(0 - c.tcnt);
+			if (db < d) d = db;
+			if (dz < d) d = dz;
+			unsigned long long at = ((now >> shift) + d + 1) << shift;
+			if (at < next) next = at;
+		}
+		nextEvent = next;
+	}
+	/* Bring the counters to where the original per-instruction tick would
+	 * have left them before this instruction started. */
+	void catchUp()
+	{
+		if (state->instrStartCycles > lastCycles) update(state->instrStartCycles);
 	}
 	virtual uint8_t read(uint32_t address) {
 		if (address<0xffff60 || address >= 0xffffa0) return 0;
+		catchUp();
 		address -= 0xffff60;
 		switch (address)
 		{
@@ -94,6 +143,8 @@ public:
 		
 	virtual void write(uint32_t address, uint8_t value) {
 		if (address<0xffff60 || address >= 0xffffa0) return;
+		catchUp();
+		nextEvent = 0;	// any write can change the schedule; recompute on the next tick
 		address -= 0xffff60;
 		switch (address)
 		{
@@ -130,6 +181,7 @@ public:
 
 private:	// 0x9f -> 0x60
 	unsigned long long lastCycles {0};
+	unsigned long long nextEvent {0};
 	int8 space[64] {};
 	uint8 tstr {0xc0}, tsnc {0xc0}, tmdr {0x80}, tfcr {0xc0};	// timer start, timer sync, timer mode reg, timer function control
 	class channel


### PR DESCRIPTION
Note: the below was created heavily via Claude, but the results have been verified both via the test bench and by a human, running on real hardware. 


`Timers::tick()` runs once per instruction and steps every elapsed cycle of every
running channel — roughly 180 iterations per sample per channel, almost all of
them just `tcnt++`. Only the cycles where a channel actually reaches `gra`, `grb`
or wraps to 0 do anything.

This computes the first cycle at which that can happen (`nextEvent`) and, until
then, `tick()` is a single compare; the inner loop jumps straight to the next
event.

### Why it is safe

`timers.tick()` runs **after** `emu.step()`, so the old code updated the counters
to end-of-instruction cycles. `catchUp()` uses `instrStartCycles`, which is
exactly that point, and it runs on any register access — so the CPU can never
observe a stale `tcnt`.

Deferred increments equal per-instruction ones because `inc` is a difference of
floors, and that is additive across any split of the interval.

Two things a reviewer will want to check, called out rather than buried:

- The skip conditions in `update()` and in the `nextEvent` recompute must stay in
  lockstep. If one skips a case the other does not, the horizon is wrong.
- `write()` resets `nextEvent`, because a register write can move the next event
  earlier.

### Measured

Upstream's own `jeTestConsole`, on an idle Raspberry Pi 4B @ 1.8 GHz
(`throttled=0x0`, checked before and after). Counterbalanced B,A,A,B rather than
alternating, because thermal drift plus straight alternation manufactured a
result here once that did not survive:

| position | build | speed | wav bytes |
|----------|-------|-------|-----------|
| 1st | before | 43% | 68,135,468 |
| 2nd | after  | 45% | 71,887,916 |
| 3rd | after  | 45% | 71,518,508 |
| 4th | before | 42% | 67,905,068 |

**≈ +6%.** `after` wins in both middle positions, and `before` reads 43% first
and 42% last, consistent with the 50.6 → 58.4 °C drift across the session. The
wav sizes corroborate from an independent measure: 5.4% more audio rendered in
the same wall clock.

### Bit-exact

All 68,135,424 audio bytes identical.

Worth stating how, because the raw hashes differ and that looks alarming: each
run is stopped on a wall clock, so the faster build simply writes **more** audio.
The comparison is the shorter file as a prefix of the longer:

```
cmp -n $(stat -c %s before.wav) -i 44:44 before.wav after.wav
```

### Scope

Measured on ARM64 (Cortex-A72) only. I have no x86 hardware to test on, and
timing under emulation would be meaningless, so I am not making a claim for x86 —
the change is architecture-neutral, but the number is not.
