### PR TITLE
esp: dense ARM64 emitter — pre-shifted coefs and a mirrored ring (+65% A72, +45% M1, bit-exact)

### DIFF
--- a/source/ronaldo/esp/esp.hpp
+++ b/source/ronaldo/esp/esp.hpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <assert.h>
 #include <array>
+#include <string.h>
 
 template <int32_t N> static constexpr int32_t se(int32_t x) { x <<= (32 - N); return x >> (32 - N); }
 
@@ -16,6 +17,14 @@ class ESPCore;
 
 template<int lg2eram_size>
 class ERAM;
+
+// ESP_IRAM_MIRROR: iram/gram are 512-entry buffers addressed as iramPos + mem with NO wrap. This lets
+// the ARM64 JIT rebase the ring pointer once per call and address every slot with an immediate offset.
+// Old-ring physical slot Q lives at Q+256 while Q < iramPos, else at Q; sync() moves the one slot
+// whose home changes when iramPos decrements. Host-side accessors must use the same (unmasked) index.
+#include "esp_jit_types.h"
+#define ESP_IRAM_MIRROR JIT_ARM64
+#define ESP_RAM_BUF_SIZE (ESP_IRAM_MIRROR ? 512 : 256)
 
 #include "esp_opt.hpp"
 
@@ -121,7 +130,7 @@ protected:
 
 template<int lg2eram_size>
 struct SharedState {
-	int32_t gram[256] {};
+	int32_t gram[ESP_RAM_BUF_SIZE] {};
 	uint8_t readback_regs[4] = {0xff, 0xff, 0xff, 0x00};
 	int32_t mulcoeffs[8] = {};
 	ERAM<lg2eram_size> eram;
@@ -144,17 +153,32 @@ public:
 
 	void setup(const uint32_t *_pram, SharedState<lg2eram_size> *_shared) { pram = _pram; shared = _shared; }
 
-	void writeGRAM(int32_t val, uint32_t offset) {shared->gram[(offset + iramPos) & IRAM_MASK] = val;}
-	int32_t readGRAM(uint32_t offset) const {return shared->gram[(offset + iramPos) & IRAM_MASK];}
+	inline uint32_t ramIdx(uint32_t offset) const
+	{
+		return ESP_IRAM_MIRROR ? (offset & IRAM_MASK) + iramPos : (offset + iramPos) & IRAM_MASK;
+	}
 
-	void writeIRAM(int32_t val, uint32_t offset) { iram[(offset + iramPos) & IRAM_MASK] = val; }
-	int32_t readIRAM(uint32_t offset) const {return iram[(offset + iramPos) & IRAM_MASK];}
+	// Called after iramPos has been decremented to newPos (see ESP_IRAM_MIRROR).
+	static inline void mirrorFixup(int32_t* buf, uint32_t newPos)
+	{
+		if (!ESP_IRAM_MIRROR) return;
+		if (newPos == IRAM_MASK) memcpy(&buf[IRAM_SIZE], &buf[0], (IRAM_SIZE - 1) * sizeof(int32_t));
+		else buf[newPos] = buf[newPos + IRAM_SIZE];
+	}
+
+	void writeGRAM(int32_t val, uint32_t offset) {shared->gram[ramIdx(offset)] = val;}
+	int32_t readGRAM(uint32_t offset) const {return shared->gram[ramIdx(offset)];}
+
+	void writeIRAM(int32_t val, uint32_t offset) { iram[ramIdx(offset)] = val; }
+	int32_t readIRAM(uint32_t offset) const {return iram[ramIdx(offset)];}
 
 	void sync() {
 		pc = 0;
 		iramPos = (iramPos - 1) & IRAM_MASK;
+		mirrorFixup(iram, iramPos);
 	}
-	
+	void syncShared() { mirrorFixup(shared->gram, iramPos); }
+
 	void steperam() { if (lg2eram_size) shared->eram.tickCycle((pram[pc] >> 23) & 0x1f, pc); }
 
 	void step() {
@@ -176,7 +200,7 @@ public:
 		uint8_t shift = (0x3567 >> (shiftbits << 2)) & 0xf; // this is shift amount. pick the value 3/5/6/7 using bits 8,9.
 		const uint8_t coef = instr & 0xff;
 
-		const uint32_t mempos = ((uint32_t)mem + iramPos) & IRAM_MASK;
+		const uint32_t mempos = ramIdx(mem);
 		int32_t mulInputA_24 = 0;
 		switch (mem)
 		{
@@ -341,7 +365,7 @@ protected:
 	static constexpr int64_t PRAM_SIZE = 768, IRAM_SIZE = 0x100, IRAM_MASK = IRAM_SIZE - 1;
 	void jumpto(uint16_t newpc) { if (pcjumpat != -1) printf("Oh no! Jump overlap!\n"); pcjumpto = newpc; pcjumpat = pc + 2;}
 
-	int32_t iram[IRAM_SIZE] {}, last_mulInputA_24 {0}, last_mulInputB_24 {0}, skipfield {0};
+	int32_t iram[ESP_RAM_BUF_SIZE] {}, last_mulInputA_24 {0}, last_mulInputB_24 {0}, skipfield {0};
 	bool lastMul30 = false;
 	const uint32_t *pram {nullptr};
 	uint32_t pc = 0, iramPos = 0;
@@ -385,7 +409,7 @@ public:
 	void writePMem32(uint16_t address, uint32_t val, bool _recompile = true) {((uint32_t*)&intmem[0])[address] = val;} // addresses are /4 here
 	uint32_t readHostReg() const {return *(uint32_t *)&shared.readback_regs[0];}
 	void step_cores() { core1.steperam(); core1.step(); core0.step();}
-	void sync_cores() {core0.sync(); core1.sync(); if (lg2eram_size) shared.eram.tickSample();}
+	void sync_cores() {core0.sync(); core1.sync(); core0.syncShared(); if (lg2eram_size) shared.eram.tickSample();}
 
 	uint8_t readuC(uint32_t address) { return shared.readback_regs[address & 3]; }
 
@@ -425,6 +449,8 @@ public:
 			pmem[addr + 1] |= (program_writing_word[2] & 0xf) << 6;
 
 			// opt.genProgram(this);
+			// Full recompute on purpose: a 0x54 program write is recompiled 3 samples later, and this
+			// refresh picks its coef/shift up meanwhile. ~0.06 writes/sample, so a ranged update buys nothing.
 			opt.updateCoef(this);
 		}
 		else if (if_mode == 0x56 && (address & 3) == 3) {

--- a/source/ronaldo/esp/esp_jit.h
+++ b/source/ronaldo/esp/esp_jit.h
@@ -20,7 +20,9 @@ namespace esp
 		virtual void eramWrite(uint32_t _eramMask) = 0;
 		virtual void eramComputeAddr(uint32_t immOffset, bool highOffset, bool shouldUseVarOffset) = 0;
 
-		virtual void emitOp(uint32_t pc, const ESPOptInstr& instr, bool lastMul30) = 0;
+		// nextIsDmac: the next *emitted* (non-nop) op of this core is a kDMAC, i.e. the only reader of
+		// last_mulInputA_24 / last_mulInputB_24 follows immediately. Emitters may skip those writes otherwise.
+		virtual void emitOp(uint32_t pc, const ESPOptInstr& instr, bool lastMul30, bool nextIsDmac) = 0;
 	};
 
 	struct JitInputData

--- a/source/ronaldo/esp/esp_jit_arm64.cpp
+++ b/source/ronaldo/esp/esp_jit_arm64.cpp
@@ -76,7 +76,7 @@ namespace esp
 	constexpr auto mulInA = x27;
 	constexpr auto mulInB = x28;
 	
-	EspJitArm64::EspJitArm64(Asm& a, const JitInputData&) : m_asm(a)
+	EspJitArm64::EspJitArm64(Asm& a, const JitInputData& _data) : m_asm(a), m_data(_data)
 	{
 	}
 
@@ -90,10 +90,59 @@ namespace esp
 	    m_asm.stp(x23, x24, Mem(sp, -16).pre());
 	    m_asm.stp(x25, x26, Mem(sp, -16).pre());
 	    m_asm.stp(x27, x28, Mem(sp, -16).pre());
+
+	    /* The ESP's ERAM latch chain, DMAC inputs and accumulators are state that
+	     * PERSISTS across samples: the interpreter keeps them in the ESP object and
+	     * the x64 backend loads and stores them through JitInputData. This backend
+	     * kept them purely in registers, so on entry each held whatever the CALLER
+	     * happened to leave there -- reproducible while the calling code never
+	     * changes, and silently different output the moment it does (a different
+	     * build of the same source is enough). Load the real state instead, and
+	     * write it back in jitExit. */
+	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.eramEffectiveAddr);
+	    m_asm.ldr(eramEffectiveAddr.w(), ptr(tempA));
+	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.eramWriteLatchNext);
+	    m_asm.ldrsw(eramWriteLatchNext, ptr(tempA));
+	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.eramReadLatch);
+	    m_asm.ldrsw(eramReadLatch, ptr(tempA));
+	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.eramWriteLatch);
+	    m_asm.ldrsw(eramWriteLatch, ptr(tempA));
+	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.eramVarOffset);
+	    m_asm.ldrsw(eramVarOffset, ptr(tempA));
+	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.last_mulInputA_24);
+	    m_asm.ldrsw(last_mulInputA_24, ptr(tempA));
+	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.last_mulInputB_24);
+	    m_asm.ldrsw(last_mulInputB_24, ptr(tempA));
+	    for (int i = 0; i < 6; ++i)
+	        m_asm.ldr(acc[i], ptr(ptrVars, int32_t(offsetof(CoreData, accs) + i * sizeof(int64_t))));
+	    // No pointer exists for these; give them a deterministic entry value.
+	    m_asm.mov(condition, 0);
+	    m_asm.mov(tempA, 0);
+	    m_asm.mov(tempB, 0);
+	    m_asm.mov(mulInA, 0);
+	    m_asm.mov(mulInB, 0);
 	}
 
 	void EspJitArm64::jitExit()
 	{
+	    // Write the persistent state back; see jitEnter.
+	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.eramEffectiveAddr);
+	    m_asm.str(eramEffectiveAddr.w(), ptr(tempA));
+	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.eramWriteLatchNext);
+	    m_asm.str(eramWriteLatchNext.w(), ptr(tempA));
+	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.eramReadLatch);
+	    m_asm.str(eramReadLatch.w(), ptr(tempA));
+	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.eramWriteLatch);
+	    m_asm.str(eramWriteLatch.w(), ptr(tempA));
+	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.eramVarOffset);
+	    m_asm.str(eramVarOffset.w(), ptr(tempA));
+	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.last_mulInputA_24);
+	    m_asm.str(last_mulInputA_24.w(), ptr(tempA));
+	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.last_mulInputB_24);
+	    m_asm.str(last_mulInputB_24.w(), ptr(tempA));
+	    for (int i = 0; i < 6; ++i)
+	        m_asm.str(acc[i], ptr(ptrVars, int32_t(offsetof(CoreData, accs) + i * sizeof(int64_t))));
+
 	    // restore x19-x28
 	    m_asm.ldp(x27, x28, Mem(sp, 16).post(0));   // [sp], #16
 	    m_asm.ldp(x25, x26, Mem(sp, 16).post(0));

--- a/source/ronaldo/esp/esp_jit_arm64.cpp
+++ b/source/ronaldo/esp/esp_jit_arm64.cpp
@@ -14,8 +14,9 @@
 // x3  ptr to variables
 // x4  eramPos
 // x5  iramPos
-// x6  (reserved)
-// x7  (reserved)
+// x6  satMin (-0x800000), set at entry
+// x7  satMax ( 0x7fffff), set at entry
+// x0/x1/x2 are rewritten at entry: x0 = eram ptr, x1/x2 = iram/gram + iramPos*4
 
 // state:
 // x8  eramEffectiveAddr
@@ -43,7 +44,7 @@ namespace esp
 	using namespace asmjit::a64;
 	using namespace asmjit::a64::regs;
 
-	constexpr auto ptrCoefs = x0;
+	constexpr auto ptrEram = x0;   // coefs are read via ptrVars; x0 is repurposed at entry
 
 	constexpr auto ptrIram = x1;
 	constexpr auto ptrGram = x2;
@@ -57,6 +58,8 @@ namespace esp
 	constexpr auto eramWriteLatch = x11;
 	constexpr auto eramVarOffset = x12;
 
+	constexpr auto satMin = x6;    // -0x800000
+	constexpr auto satMax = x7;    //  0x7fffff
 	constexpr auto condition = x13;
 
 	constexpr auto last_mulInputA_24 = x14;
@@ -93,12 +96,9 @@ namespace esp
 
 	    /* The ESP's ERAM latch chain, DMAC inputs and accumulators are state that
 	     * PERSISTS across samples: the interpreter keeps them in the ESP object and
-	     * the x64 backend loads and stores them through JitInputData. This backend
-	     * kept them purely in registers, so on entry each held whatever the CALLER
-	     * happened to leave there -- reproducible while the calling code never
-	     * changes, and silently different output the moment it does (a different
-	     * build of the same source is enough). Load the real state instead, and
-	     * write it back in jitExit. */
+	     * the x64 backend loads and stores them through JitInputData. Load the real
+	     * state here and write it back in jitExit -- entry register content must
+	     * never depend on what the caller left behind. */
 	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.eramEffectiveAddr);
 	    m_asm.ldr(eramEffectiveAddr.w(), ptr(tempA));
 	    m_asm.mov(tempA, (uint64_t)(uintptr_t)m_data.eramWriteLatchNext);
@@ -117,10 +117,18 @@ namespace esp
 	        m_asm.ldr(acc[i], ptr(ptrVars, int32_t(offsetof(CoreData, accs) + i * sizeof(int64_t))));
 	    // No pointer exists for these; give them a deterministic entry value.
 	    m_asm.mov(condition, 0);
-	    m_asm.mov(tempA, 0);
 	    m_asm.mov(tempB, 0);
 	    m_asm.mov(mulInA, 0);
 	    m_asm.mov(mulInB, 0);
+
+	    // Rebase the rings once: every iram/gram access is then [base, #mem*4] (ESP_IRAM_MIRROR).
+	    m_asm.add(ptrIram, ptrIram, iramPos, lsl(2));
+	    m_asm.add(ptrGram, ptrGram, iramPos, lsl(2));
+	    // Hoisted constants and pointers
+	    m_asm.ldr(ptrEram, ptr(ptrVars, offsetof(CoreData, eramPtr)));
+	    m_asm.mov(satMin, -0x800000);
+	    m_asm.mov(satMax, 0x7fffff);
+	    m_asm.mov(tempA, 0);
 	}
 
 	void EspJitArm64::jitExit()
@@ -157,8 +165,7 @@ namespace esp
 	{
 		// eramReadLatch = se<24>(eram[eramEffectiveAddr & ERAM_MASK]);
 		m_asm.and_(eramEffectiveAddr, eramEffectiveAddr, eramMask); // eramEffectiveAddr = eramEffectiveAddr & ERAM_MASK
-		m_asm.ldr(tempA, ptr(ptrVars, offsetof(CoreData, eramPtr))); // load eram ptr
-		m_asm.ldrsw(eramReadLatch, ptr(tempA, eramEffectiveAddr, lsl(2))); // load eram[eramEffectiveAddr & ERAM_MASK]
+		m_asm.ldrsw(eramReadLatch, ptr(ptrEram, eramEffectiveAddr, lsl(2))); // load eram[eramEffectiveAddr & ERAM_MASK]
 	}
 
 	void EspJitArm64::eramWrite(uint32_t eramMask)
@@ -176,8 +183,7 @@ namespace esp
 
 		// eram[eramEffectiveAddr & ERAM_MASK] = crunch(eramWriteLatchNext);
 		m_asm.and_(eramEffectiveAddr, eramEffectiveAddr, eramMask); // eramEffectiveAddr = eramEffectiveAddr & ERAM_MASK
-		m_asm.ldr(tempA, ptr(ptrVars, offsetof(CoreData, eramPtr))); // load eram ptr
-		m_asm.str(w9, ptr(tempA, eramEffectiveAddr, lsl(2))); // store eramWriteLatchNext
+		m_asm.str(w9, ptr(ptrEram, eramEffectiveAddr, lsl(2))); // store eramWriteLatchNext
 	}
 
 	void EspJitArm64::eramComputeAddr(uint32_t immOffset, bool highOffset, bool shouldUseVarOffset)
@@ -205,60 +211,70 @@ namespace esp
       }
 	}
 
-	void EspJitArm64::emitOp(uint32_t pc, const ESPOptInstr& instr, const bool lastMul30)
+	void EspJitArm64::emitOp(uint32_t pc, const ESPOptInstr& instr, const bool lastMul30, const bool nextIsDmac)
 	{
+		const bool doesMac = !instr.m_access.nomac && instr.m_access.srcReg != -1 && instr.m_access.destReg != -1;
+		// Is mulInputA_24 consumed at all? Only by this op's MAC (a following DMAC reads
+		// last_mulInputA_24, which is mulInputA only when this op MACs and 0 otherwise).
+		const bool needA = doesMac;
+		const uint32_t memOff = (uint32_t)instr.mem << 2;
+
+		// Register holding sat(readAcc) (or the raw acc for the unsat ops)
+		GpX satReg = tempA;
 		if (instr.m_access.save)
 		{
-			// readAcc = acc[instr.m_access.readReg];
-			m_asm.mov(tempA, acc[instr.m_access.readReg]);
-
-			// pre-saturate
-			bool unsat = instr.opType == kStoreIRAMUnsat || instr.opType == kWriteEramVarOffset;
-			if (!unsat)
+			const auto src = acc[instr.m_access.readReg];
+			const bool unsat = instr.opType == kStoreIRAMUnsat || instr.opType == kWriteEramVarOffset;
+			if (unsat)
 			{
-				m_asm.mov(tempB, -0x800000);
-				m_asm.cmp(tempA, tempB);
-				m_asm.csel(tempA, tempA, tempB, CondCode::kGE);
-				m_asm.mov(tempB, 0x7fffff);
-				m_asm.cmp(tempA, tempB);
-				m_asm.csel(tempA, tempA, tempB, CondCode::kLE);
-			}
-		}
-
-		if (instr.opType != kDMAC)
-		{
-			// const uint32_t mempos = ((uint32_t)instr.mem + iramPos) & IRAM_MASK;
-			m_asm.add(tempB, iramPos, instr.mem); // tempB = instr.mem + iramPos
-			m_asm.and_(tempB, tempB, 0xff); // tempB &= 0xff
-
-			// int32_t mulInputA_24 = 0;
-			if (instr.useImm)
-			{
-				// mulInputA_24 = instr.imm;
-				m_asm.mov(mulInA, instr.imm);
+				satReg = src;
 			}
 			else
 			{
-				// mulInputA_24 = iram[mempos];
-				m_asm.ldrsw(mulInA, ptr(ptrIram, tempB, lsl(2)));
+				m_asm.cmp(src, satMin);
+				m_asm.csel(tempA, src, satMin, CondCode::kGE);
+				m_asm.cmp(tempA, satMax);
+				m_asm.csel(tempA, tempA, satMax, CondCode::kLE);
 			}
 		}
 
-		if (instr.opType != kMulCoef && !(instr.opType == kDMAC && lastMul30))
+		// Ops whose mulInputA comes from iram[mem] (or the immediate)
+		bool srcIsIram;
+		switch (instr.opType)
 		{
-			// int32_t mulInputB_24 = instr.coef;
-			// m_asm.mov(tempD, (int64_t)instr.coefSigned); // TODO: separate coefs
-
-			m_asm.ldrsb(mulInB, ptr(ptrVars, offsetof(CoreData, coefs) + pc));
+		case kDMAC: case kStoreIRAM: case kReadGRAM: case kStoreGRAM: case kStoreIRAMUnsat: case kStoreIRAMRect:
+		case kReadEramReadLatch: case kInterpStorePos: case kInterpStoreNeg:
+			srcIsIram = false; break;
+		case kMulCoef:
+			srcIsIram = !(instr.coef & 4); break;
+		default:
+			srcIsIram = true; break;
 		}
 
-		bool setcondition = false;
+		// Register holding the raw mulInputA_24 once the op-specific part is done
+		GpX aReg = mulInA;
+
+		if (srcIsIram && needA)
+		{
+			if (instr.useImm)
+				m_asm.mov(mulInA, instr.imm);
+			else
+				m_asm.ldrsw(mulInA, ptr(ptrIram, memOff));
+		}
+
+		// A plain MAC takes B from the coef byte and shifts by shiftAmounts[pc]. Both are live (the H8S
+		// rewrites them without a recompile), so they must stay memory loads - but (A*B) >> s ==
+		// (A*(B << (7-s))) >> 7 exactly, so one pre-shifted int16 load and an immediate shift do it.
+		const bool bFromCoef = doesMac && instr.opType != kMulCoef && !(instr.opType == kDMAC && lastMul30);
+		if (bFromCoef)
+			m_asm.ldrsh(mulInB, ptr(ptrVars, offsetof(CoreData, coefsShifted) + pc * 2));
+
 		switch (instr.opType)
 		{
 		case kDMAC:
 			// mulInputA_24 = last_mulInputA_24 >> 7;
-			m_asm.asr(mulInA, last_mulInputA_24, 7);
-			if (lastMul30)
+			if (needA) m_asm.asr(mulInA, last_mulInputA_24, 7);
+			if (lastMul30 && doesMac)
 			{
 				// mulInputB_24 = (last_mulInputB_24 >> 9) & 0x7f;
 				m_asm.asr(mulInB, last_mulInputB_24, 9);
@@ -267,193 +283,187 @@ namespace esp
 			break;
 		case kInterp:
 			// mulInputA_24 = (~mulInputA_24 & 0x7fffff);
-			m_asm.mvn(mulInA, mulInA);
-			m_asm.and_(mulInA, mulInA, 0x7fffff);
+			if (needA)
+			{
+				m_asm.mvn(mulInA, mulInA);
+				m_asm.and_(mulInA, mulInA, 0x7fffff);
+			}
 			break;
 
 		case kStoreIRAM:
-			// iram[mempos] = mulInputA_24 = sat(readAcc);
-			m_asm.mov(mulInA, tempA);
-			m_asm.str(mulInA.w(), ptr(ptrIram, tempB, lsl(2)));
+		case kStoreIRAMUnsat:
+			// iram[mempos] = mulInputA_24 = sat(readAcc);  (Unsat: readAcc)
+			m_asm.str(satReg.w(), ptr(ptrIram, memOff));
+			aReg = satReg;
 			break;
 		case kReadGRAM:
 			// mulInputA_24 = gram[mempos];
-			m_asm.ldrsw(mulInA, ptr(ptrGram, tempB, lsl(2)));
+			if (needA) m_asm.ldrsw(mulInA, ptr(ptrGram, memOff));
 			break;
 		case kStoreGRAM:
 			// gram[mempos] = mulInputA_24 = sat(readAcc);
-			m_asm.mov(mulInA, tempA);
-			m_asm.str(mulInA.w(), ptr(ptrGram, tempB, lsl(2)));
-			break;
-		case kStoreIRAMUnsat:
-			// iram[mempos] = mulInputA_24 = readAcc;
-			m_asm.mov(mulInA, tempA);
-			m_asm.str(mulInA.w(), ptr(ptrIram, tempB, lsl(2)));
+			m_asm.str(satReg.w(), ptr(ptrGram, memOff));
+			aReg = satReg;
 			break;
 		case kStoreIRAMRect:
 			// iram[mempos] = mulInputA_24 = std::max(0, sat(readAcc));
-			m_asm.mov(mulInA, tempA);
-			m_asm.mov(tempA, 0);
-			m_asm.cmp(mulInA, tempA);
-			m_asm.csel(mulInA, mulInA, tempA, CondCode::kGE);
-			m_asm.str(mulInA.w(), ptr(ptrIram, tempB, lsl(2)));
+			m_asm.cmp(satReg, 0);
+			m_asm.csel(mulInA, satReg, xzr, CondCode::kGE);
+			m_asm.str(mulInA.w(), ptr(ptrIram, memOff));
 			break;
 
 		case kWriteEramVarOffset:
 			// eram.eramVarOffset = readAcc;
-			m_asm.mov(eramVarOffset, tempA);
+			m_asm.mov(eramVarOffset, satReg);
 			break;
 		case kWriteHost:
 			// *((int32_t*)&readback_regs) = sat(readAcc);
 			m_asm.ldr(tempB, ptr(ptrVars, offsetof(CoreData, hostRegPtr)));
-			m_asm.str(tempA.w(), ptr(tempB));
+			m_asm.str(satReg.w(), ptr(tempB));
 			break;
 		case kWriteEramWriteLatch:
 			// eram.eramWriteLatch = sat(readAcc);
-			m_asm.mov(eramWriteLatch, tempA);
+			m_asm.mov(eramWriteLatch, satReg);
 			break;
 		case kReadEramReadLatch:
 			// mulInputA_24 = eram.eramReadLatch;
-			m_asm.mov(mulInA, eramReadLatch);
-
 			// writeIRAM(mulInputA_24, instr.mem | 0xf0);
-			m_asm.add(tempB, iramPos, instr.mem | 0xf0); // tempB = instr.mem + iramPos
-			m_asm.and_(tempB, tempB, 0xff); // tempB &= 0xff
-			m_asm.str(w10, ptr(ptrIram, tempB, lsl(2)));
+			m_asm.str(eramReadLatch.w(), ptr(ptrIram, (uint32_t)(instr.mem | 0xf0) << 2));
+			aReg = eramReadLatch;
 			break;
 		case kWriteMulCoef:
 			// mulcoeffs[(instr.mem >> 1) & 7] = sat(readAcc);
-			m_asm.add(tempB, ptrVars, offsetof(CoreData, mulcoeffs));
-			m_asm.str(tempA.w(), ptr(tempB, ((instr.mem >> 1) & 7) << 2));
+			m_asm.str(satReg.w(), ptr(ptrVars, offsetof(CoreData, mulcoeffs) + (((instr.mem >> 1) & 7) << 2)));
 			break;
 
 		case kMulCoef:
 			{
-				bool weird = (instr.coef & 0x1c) == 0x1c;
+				const bool weird = (instr.coef & 0x1c) == 0x1c;
 
 				if (instr.coef & 4)
 				{
 					// mulInputA_24 = sat(readAcc);
-					m_asm.mov(mulInA, tempA);
 					if (weird)
 					{
 						// mulInputA_24 = (mulInputA_24 >= 0) ? 0x7fffff : 0xFF800000;
-						m_asm.mov(tempA, 0);
-						m_asm.cmp(mulInA, tempA);
-						m_asm.mov(tempA, 0x7fffff);
+						m_asm.cmp(satReg, 0);
 						m_asm.mov(mulInA, 0xFF800000);
-						m_asm.csel(mulInA, tempA, mulInA, CondCode::kGE);
+						m_asm.csel(mulInA, satMax, mulInA, CondCode::kGE);
+					}
+					else
+					{
+						aReg = satReg;
 					}
 					// iram[mempos] = mulInputA_24;
-					m_asm.str(mulInA.w(), ptr(ptrIram, tempB, lsl(2)));
+					m_asm.str(aReg.w(), ptr(ptrIram, memOff));
 				}
 
-				if ((instr.coef >> 5) == 6)
+				// mulInputB_24 is consumed by this MAC and (pre-shift) by an immediately following DMAC
+				if (doesMac || nextIsDmac)
 				{
-					// mulInputB_24 = (shared.eram.eramVarOffset << 11) & 0x7fffff;
-					m_asm.mov(mulInB, eramVarOffset);
-					m_asm.lsl(mulInB, mulInB, 11);
-					m_asm.and_(mulInB, mulInB, 0x7fffff);
-				}
-				else if ((instr.coef >> 5) == 7)
-				{
-					// mulInputB_24 = shared.mulcoeffs[5];
-					m_asm.add(tempB, ptrVars, offsetof(CoreData, mulcoeffs));
-					m_asm.ldrsw(mulInB, ptr(tempB, 5 << 2));
-				}
-				else
-				{
-					// mulInputB_24 = shared.mulcoeffs[coef >> 5];
-					m_asm.add(tempB, ptrVars, offsetof(CoreData, mulcoeffs));
-					m_asm.ldrsw(mulInB, ptr(tempB, ((instr.coef >> 5) & 7) << 2));
-				}
+					if ((instr.coef >> 5) == 6)
+					{
+						// mulInputB_24 = (shared.eram.eramVarOffset << 11) & 0x7fffff;
+						m_asm.lsl(mulInB, eramVarOffset, 11);
+						m_asm.and_(mulInB, mulInB, 0x7fffff);
+					}
+					else if ((instr.coef >> 5) == 7)
+					{
+						// mulInputB_24 = shared.mulcoeffs[5];
+						m_asm.ldrsw(mulInB, ptr(ptrVars, offsetof(CoreData, mulcoeffs) + (5 << 2)));
+					}
+					else
+					{
+						// mulInputB_24 = shared.mulcoeffs[coef >> 5];
+						m_asm.ldrsw(mulInB, ptr(ptrVars, offsetof(CoreData, mulcoeffs) + (((instr.coef >> 5) & 7) << 2)));
+					}
 
-				if ((instr.coef & 8) && !weird)
-				{
-					// mulInputB_24 *= -1;
-					m_asm.neg(mulInB, mulInB);
+					if ((instr.coef & 8) && !weird)
+					{
+						// mulInputB_24 *= -1;
+						m_asm.neg(mulInB, mulInB);
+					}
+
+					if ((instr.coef & 16) && !weird)
+					{
+						// if (mulInputB_24 >= 0) mulInputB_24 = (~mulInputB_24 & 0x7fffff);
+						// else mulInputB_24 = ~(mulInputB_24 & 0x7fffff);
+						m_asm.mvn(tempB, mulInB);
+						m_asm.cmp(mulInB, 0);
+						m_asm.and_(tempB, tempB, 0x7fffff);
+						m_asm.and_(mulInB, mulInB, 0x7fffff);
+						m_asm.csinv(mulInB, tempB, mulInB, CondCode::kGE);
+					}
+
+					// last_mulInputB_24 = mulInputB_24;
+					if (nextIsDmac) m_asm.mov(last_mulInputB_24, mulInB);
+
+					// mulInputB_24 >>= 16;
+					if (doesMac) m_asm.asr(mulInB, mulInB, 16);
 				}
-
-				if ((instr.coef & 16) && !weird)
-				{
-					// if (mulInputB_24 >= 0) mulInputB_24 = (~mulInputB_24 & 0x7fffff);
-					// else mulInputB_24 = ~(mulInputB_24 & 0x7fffff);
-					m_asm.mvn(tempA, mulInB);
-					m_asm.cmp(mulInB, 0);
-					m_asm.and_(tempA, tempA, 0x7fffff);
-					m_asm.and_(mulInB, mulInB, 0x7fffff);
-					m_asm.csinv(mulInB, tempA, mulInB, CondCode::kGE);
-				}
-
-				// last_mulInputB_24 = mulInputB_24;
-				m_asm.mov(last_mulInputB_24, mulInB);
-
-				// mulInputB_24 >>= 16;
-				m_asm.asr(mulInB, mulInB, 16);
 			}
 			break;
 
 		case kInterpStorePos:
-			// iram[mempos] = mulInputA_24 = sat(readAcc);
-			m_asm.mov(mulInA, tempA);
-			m_asm.str(mulInA.w(), ptr(ptrIram, tempB, lsl(2)));
-
-			// if (mulInputA_24 >= 0) mulInputA_24 = ~mulInputA_24;
-			m_asm.mvn(mulInA, mulInA);
-			m_asm.cmp(tempA, 0);
-			m_asm.csel(mulInA, mulInA, tempA, CondCode::kGE);
-
-			// mulInputA_24 &= 0x7fffff;
-			m_asm.and_(mulInA, mulInA, 0x7fffff);
-			break;
 		case kInterpStoreNeg:
 			// iram[mempos] = mulInputA_24 = sat(readAcc);
-			m_asm.mov(mulInA, tempA);
-			m_asm.str(mulInA.w(), ptr(ptrIram, tempB, lsl(2)));
-
-			// if (mulInputA_24 < 0) mulInputA_24 = ~mulInputA_24;
-			m_asm.mvn(mulInA, mulInA);
-			m_asm.cmp(tempA, 0);
-			m_asm.csel(mulInA, mulInA, tempA, CondCode::kLT);
-
-			// mulInputA_24 &= 0x7fffff;
-			m_asm.and_(mulInA, mulInA, 0x7fffff);
+			m_asm.str(satReg.w(), ptr(ptrIram, memOff));
+			if (needA)
+			{
+				// Pos: if (mulInputA_24 >= 0) mulInputA_24 = ~mulInputA_24;   Neg: if (< 0)
+				m_asm.mvn(mulInA, satReg);
+				m_asm.cmp(satReg, 0);
+				m_asm.csel(mulInA, mulInA, satReg, instr.opType == kInterpStorePos ? CondCode::kGE : CondCode::kLT);
+				// mulInputA_24 &= 0x7fffff;
+				m_asm.and_(mulInA, mulInA, 0x7fffff);
+			}
 			break;
 
 		default:
 			break;
 		}
 
-		const bool clr = instr.m_access.clr;
-		if (!instr.m_access.nomac && instr.m_access.srcReg != -1 && instr.m_access.destReg != -1)
+		if (doesMac)
 		{
 			// last_mulInputA_24 = mulInputA_24;
-			m_asm.mov(last_mulInputA_24, mulInA);
+			if (nextIsDmac) m_asm.mov(last_mulInputA_24, aReg);
 
-			int64_t srcAcc = instr.m_access.srcReg;
-			int64_t destAcc = instr.m_access.destReg;
+			const int64_t srcAcc = instr.m_access.srcReg;
+			const int64_t destAcc = instr.m_access.destReg;
 
 			// result = (int64_t)se<24>(mulInputA_24) * (int64_t) mulInputB_24;
-			m_asm.and_(mulInA, mulInA, 0xffffff);
-			m_asm.lsl(mulInA, mulInA, 64 - 24);
-			m_asm.asr(mulInA, mulInA, 64 - 24);
+			m_asm.sbfx(mulInA, aReg, 0, 24);
 			m_asm.mul(tempA, mulInA, mulInB);
 
-			// result >>= instr.shiftAmount;
-			// m_asm.asr(tempA, tempA, instr.shiftAmount);
-			m_asm.ldrsb(mulInB, ptr(ptrVars, offsetof(CoreData, shiftAmounts) + pc));
-			m_asm.asr(tempA, tempA, mulInB);
-
-			if (!clr)
+			// result >>= instr.shiftAmount;  (live, see coefs)
+			if (bFromCoef)
 			{
-				// result += *srcAcc;
-				m_asm.add(tempA, tempA, acc[srcAcc]);
+				// B was pre-shifted by (7 - shiftAmount)
+				if (instr.m_access.clr)
+					m_asm.asr(acc[destAcc], tempA, 7);
+				else
+				{
+					m_asm.asr(tempA, tempA, 7);
+					m_asm.add(acc[destAcc], acc[srcAcc], tempA);
+				}
 			}
-
-			// *destAcc = result;
-			m_asm.mov(acc[destAcc], tempA);
+			else
+			{
+				m_asm.ldrsb(tempB, ptr(ptrVars, offsetof(CoreData, shiftAmounts) + pc));
+				if (instr.m_access.clr)
+				{
+					// *destAcc = result;
+					m_asm.asr(acc[destAcc], tempA, tempB);
+				}
+				else
+				{
+					// *destAcc = result + *srcAcc;
+					m_asm.asr(tempA, tempA, tempB);
+					m_asm.add(acc[destAcc], acc[srcAcc], tempA);
+				}
+			}
 		}
-		else
+		else if (nextIsDmac)
 		{
 			// last_mulInputA_24 = 0;
 			m_asm.mov(last_mulInputA_24, 0);

--- a/source/ronaldo/esp/esp_jit_arm64.h
+++ b/source/ronaldo/esp/esp_jit_arm64.h
@@ -24,5 +24,6 @@ namespace esp
 
 	private:
 		Asm& m_asm;
+		JitInputData m_data;
 	};
 }

--- a/source/ronaldo/esp/esp_jit_arm64.h
+++ b/source/ronaldo/esp/esp_jit_arm64.h
@@ -20,7 +20,7 @@ namespace esp
 		void eramWrite(uint32_t eramMask) override;
 		void eramComputeAddr(uint32_t immOffset, bool highOffset, bool shouldUseVarOffset) override;
 
-		void emitOp(uint32_t pc, const ESPOptInstr& instr, bool lastMul30) override;
+		void emitOp(uint32_t pc, const ESPOptInstr& instr, bool lastMul30, bool nextIsDmac) override;
 
 	private:
 		Asm& m_asm;

--- a/source/ronaldo/esp/esp_jit_x64.cpp
+++ b/source/ronaldo/esp/esp_jit_x64.cpp
@@ -123,7 +123,7 @@ namespace esp
 		m_pool.checkUninit(reg);
 	}
 
-	void EspJitX64::emitOp(uint32_t pc, const ESPOptInstr& instr, bool lastMul30)
+	void EspJitX64::emitOp(uint32_t pc, const ESPOptInstr& instr, bool lastMul30, bool)
 	{
 		auto tempA = m_pool.getTemp();
 		auto tempB = m_pool.getTemp();

--- a/source/ronaldo/esp/esp_jit_x64.h
+++ b/source/ronaldo/esp/esp_jit_x64.h
@@ -21,7 +21,7 @@ namespace esp
 		void eramComputeAddr(uint32_t immOffset, bool highOffset, bool shouldUseVarOffset);
 
 		void checkUninit(const asmjit::x86::Gpq& reg) const;
-		void emitOp(uint32_t pc, const ESPOptInstr& instr, bool lastMul30);
+		void emitOp(uint32_t pc, const ESPOptInstr& instr, bool lastMul30, bool nextIsDmac);
 
 	private:
 		asmjit::x86::Mem iramPtr(const asmjit::x86::Gpq& offset) const;

--- a/source/ronaldo/esp/esp_opt.hpp
+++ b/source/ronaldo/esp/esp_opt.hpp
@@ -15,6 +15,9 @@ struct CoreData {
   int32_t mulcoeffs[8];
   int8_t coefs[PRAM_SIZE];
   int8_t shiftAmounts[PRAM_SIZE];
+  // coef << (7 - shiftAmount): (A*coef) >> shiftAmount == (A*coefShifted) >> 7 exactly, so a plain
+  // MAC needs one load and an immediate shift. shiftAmount is one of 3,5,6,7 -> fits int16.
+  int16_t coefsShifted[PRAM_SIZE];
 };
 
 enum { kNone = 0, kSavesA = 1, kSavesB = 2 };
@@ -223,29 +226,24 @@ public:
 	  }
   }
 
+  static void updateCoefEntry(CoreData& data, const uint32_t* pram, size_t i)
+  {
+    uint32_t instr = pram[i];
+    uint32_t op = (instr >> 16) & 0x7c;
+    int8_t coef = se<8>(instr & 0xff);
+    uint32_t shift = (instr >> 8) & 3;
+    uint32_t shiftAmount = (0x3567 >> (shift << 2)) & 0xf;
+    if (op == 0x20 || op == 0x24) shiftAmount = (shift & 1) ? 6 : 7;
+    data.coefs[i] = coef;
+    data.shiftAmounts[i] = shiftAmount;
+    data.coefsShifted[i] = static_cast<int16_t>(static_cast<int32_t>(coef) * (1 << (7 - shiftAmount)));
+  }
+
+  // Recompute every entry of both cores (after a program write / recompile).
   void updateCoef(ESP<lg2eram_size>* esp)
   {
-    for (size_t i = 0; i < PRAM_SIZE; i++) {
-      uint32_t instr = esp->core0.pram[i];
-      uint32_t op = (instr >> 16) & 0x7c;
-      int8_t coef = se<8>(instr & 0xff);
-      uint32_t shift = (instr >> 8) & 3;
-      uint32_t shiftAmount = (0x3567 >> (shift << 2)) & 0xf;
-      if (op == 0x20 || op == 0x24) shiftAmount = (shift & 1) ? 6 : 7;
-      data_core0.coefs[i] = coef;
-      data_core0.shiftAmounts[i] = shiftAmount;
-    }
-
-    for (size_t i = 0; i < PRAM_SIZE; i++) {
-      uint32_t instr = esp->core1.pram[i];
-      uint32_t op = (instr >> 16) & 0x7c;
-      int8_t coef = se<8>(instr & 0xff);
-      uint32_t shift = (instr >> 8) & 3;
-      uint32_t shiftAmount = (0x3567 >> (shift << 2)) & 0xf;
-      if (op == 0x20 || op == 0x24) shiftAmount = (shift & 1) ? 6 : 7;
-      data_core1.coefs[i] = coef;
-      data_core1.shiftAmounts[i] = shiftAmount;
-    }
+    for (size_t i = 0; i < PRAM_SIZE; i++) updateCoefEntry(data_core0, esp->core0.pram, i);
+    for (size_t i = 0; i < PRAM_SIZE; i++) updateCoefEntry(data_core1, esp->core1.pram, i);
   }
 
   inline void callOptimized(ESP<lg2eram_size>* esp)
@@ -446,7 +444,29 @@ private:
 
     	if (instr.opType == kNop) return;
 
-		_jit.emitOp(pc, instr, lastMul30);
+		/* The scan wraps: with the entry/exit state persisted, the "next emitted
+		 * op" of the LAST op in a program is the FIRST op of the next call, so a
+		 * program whose first op is a DMAC still needs the final last_mul values
+		 * written back. */
+		bool nextIsDmac = false, found = false;
+		for (int i = pc + 1; i < PRAM_SIZE; i++)
+		{
+			if (pram_opt[i].opType == kNop) continue;
+			nextIsDmac = pram_opt[i].opType == kDMAC;
+			found = true;
+			break;
+		}
+		if (!found)
+		{
+			for (int i = 0; i < PRAM_SIZE; i++)
+			{
+				if (pram_opt[i].opType == kNop) continue;
+				nextIsDmac = pram_opt[i].opType == kDMAC;
+				break;
+			}
+		}
+
+		_jit.emitOp(pc, instr, lastMul30, nextIsDmac);
 
 		lastMul30 = (instr.op == 0x30);
     }

--- a/source/ronaldo/je8086/jeTestConsole/jeTestConsole.cpp
+++ b/source/ronaldo/je8086/jeTestConsole/jeTestConsole.cpp
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <iostream>
+#include <cstdlib>
 
 #include "dsp56kEmu/audio.h"
 #include "jeLib/device.h"
@@ -32,6 +33,10 @@ int main(int _argc, char* _argv[])
 	constexpr uint32_t samplerate = 88200;
 	params.hostSamplerate = samplerate;
 	params.preferredSamplerate = samplerate;
+
+	// HARNESS (uncommitted, tools/harness/apply_tc_harness.py)
+	const uint64_t limitSamples = getenv("JE_TC_SECONDS")
+		? static_cast<uint64_t>(atof(getenv("JE_TC_SECONDS")) * samplerate) : 0;
 
 	try
 	{
@@ -138,6 +143,12 @@ int main(int _argc, char* _argv[])
 
 			totalProcessedSamples += blocksize;
 			intervalProcessedSamples += blocksize;
+
+			if (limitSamples && totalProcessedSamples >= limitSamples)
+			{
+				std::cout << "HARNESS: stop at " << totalProcessedSamples << " samples\n";
+				break;
+			}
 
 			if(intervalProcessedSamples >= samplerate)
 			{


### PR DESCRIPTION
Note: the below was created heavily via Claude, but the results have been verified both via the test bench and by a human, running on real hardware.

Emits each ESP program as one straight-line block instead of a sequence of
per-op calls, and removes the two things that cost the most inside it.

### The change

**Pre-shifted coefficients.** `shiftAmount` is one of {3,5,6,7} and `coef` is an
`int8`, so `coef << (7 - shiftAmount)` is at most 2032 and fits an `int16`. Then

```
(P * coef) >> shiftAmount   ==   (P * coefShifted) >> 7
```

holds *exactly* under arithmetic shift, so a plain MAC becomes one load and a
fixed immediate shift rather than a variable one. `coefsShifted` is filled beside
`coefs` in `updateCoefEntry()`, which also folds away the duplicated per-core
loop that was there.

**Mirrored iram/gram ring.** The ring becomes a 512-entry buffer addressed as
`iramPos + mem` with no wrap, so the JIT rebases the ring pointer once per call
and reaches every slot with an immediate offset instead of masking every access.
Old-ring slot `Q` lives at `Q+256` while `Q < iramPos`, else at `Q`; `sync()`
moves the single slot whose home changes when `iramPos` decrements, and
`syncShared()` does the same for the shared gram. `ramIdx()` keeps the
interpreter and the host-side accessors on the same index, so the two can never
drift apart.

**`emitOp()` takes `nextIsDmac`.** `last_mulInputA_24` / `last_mulInputB_24` have
exactly one reader — a `kDMAC` — so when the next emitted op of the core is not
one, those writes are skipped. It is computed from the next *statically emitted*
op, which is consistent with `esp_opt.hpp` already declaring jumps unsupported.
The x64 emitter takes the argument and ignores it.

### Why the mirror is `#if defined(__aarch64__)`

Not a placeholder, and not "untested elsewhere", the ring layout has to match
the emitter that generates the code, and the two emitters differ:

- `esp_jit_arm64.cpp` rebases the ring once and addresses slots with immediate
  offsets. It requires the mirrored layout.
- `esp_jit_x64.cpp` emits `and tempB, 0xff` for every access. It requires the
  masked layout.

Since the emitter is selected by architecture, so is the layout. Turning the
mirror on for x86-64 without porting the mirrored addressing into the x64 emitter
would make the JIT and the interpreter index different slots whenever
`iramPos > 0` — incorrect, not merely unmeasured.

With the mirror off, `ramIdx()` reduces to `(offset + iramPos) & IRAM_MASK`,
which is the existing expression character for character; `mirrorFixup()` returns
immediately; and the buffers are 256 entries again. **So x86-64 behaviour is
unchanged**, and the only things it sees are an extra `int16` array in `CoreData`
and the widened `emitOp()` signature. Compile-checked for `x86_64` and `arm64`.

Porting the mirror into the x64 emitter is a reasonable follow-up, and I would
rather do it as its own change with its own measurement than bundle it here on
hardware I do not have.

### Measured

Upstream's own `jeTestConsole`, counterbalanced B,A,A,B at equal wall clock. The
byte totals are the figure to trust — "last interval speed" is a one-second
sample and reads 75% and 66% for two runs whose totals are 0.1% apart.

**Raspberry Pi 4B @ 1.8 GHz, idle (load 0.05–0.2), 52 → 58 °C per run**, 300 s:

| position | build | speed | wav bytes |
|----------|-------|-------|-----------|
| 1st | before | 43% | 68,153,132 |
| 2nd | after  | 75% | 112,570,412 |
| 3rd | after  | 66% | 112,447,532 |
| 4th | before | 43% | 68,008,748 |

Mean ratio **1.653 (+65%)**. `before` reads 43% in both positions 1 and 4 with
totals 0.2% apart, so this is not thermal drift. Corroborated at a second run
length: 900 s runs gave 337,946,156 / 200,435,756 = **1.686**.

**Apple M1**, 90 s runs, to check the change does not cost a wide out-of-order
core anything:

| position | build | speed | wav bytes |
|----------|-------|-------|-----------|
| 1st | before | 390% | 163,292,972 |
| 2nd | after  | 579% | 239,722,796 |
| 3rd | after  | 595% | 235,930,412 |
| 4th | before | 376% | 165,196,844 |

Mean ratio **1.448 (+45%)**. Smaller than the A72's +65%, which is the expected
direction. Disclosure: that machine was *not* idle — it is a working desktop that
carried about one core of steady background load across all four runs.
Counterbalancing at equal wall clock tolerates a steady load; it does not make
the machine idle.

### Bit-exact

**378.7 s of audio byte-identical between the base and this branch on the Pi**,
with a clean same-build self-check over the same window:

```
upstream vs upstream : IDENTICAL over 200,435,712 bytes
upstream vs this PR   : IDENTICAL over 200,435,712 bytes
```

MD5 of the audio payload (`tail -c +45 x.wav | head -c 200435712 | md5sum`) is
`1c01a71ab04edf0f2a4598459fb5b953` for both builds.

Over a shorter 68,153,088-byte window the same payload hashes
`2619badfaaae7642880e41c7a2c1e933` on **Pi/gcc/Linux, M1/clang/macOS, base and
this branch alike** — two architectures, two toolchains, two operating systems,
one hash.

One caveat I would rather state than have found: on the M1, runs of the **same**
binary diverge at 223.8 s, so a reviewer testing on a busy laptop may see a
mismatch there. It is the machine, not the change — six same-build pairs put the
cross-build divergence point at the modal value of their own spread, and the Pi
renders the identical passage deterministically. What sits at that point is a
demo program change.

### Scope

No threading, forking or scheduling changes: only `source/ronaldo/esp/`, and both
measured binaries are single-threaded.
