### PR TITLE
esp: recompile only the core whose program words were written (~50% fewer compiles at patch change)

### DIFF
--- a/source/ronaldo/esp/esp.hpp
+++ b/source/ronaldo/esp/esp.hpp
@@ -409,7 +409,7 @@ public:
 			auto newValue = *reinterpret_cast<uint32_t*>(&intmem[(addr << 2)]);
 
 			if (newValue != oldValue)
-				opt.setProgramDirty();
+				opt.setProgramDirty(addr < 0x400 ? 1 : 2);	// core 0 owns words 0..0x3ff, core 1 the rest
 		}
 		else if (if_mode == 0x55 && (address & 3) == 3) {
 			const int addr = address >> 2;
@@ -463,7 +463,9 @@ public:
 			};
 
 			if (newValues != oldValues)
-				opt.setProgramDirty();
+				// This path writes pmem[addr] .. pmem[addr + 4], so a burst that starts below the
+				// 0x400 boundary and ends at or above it dirties BOTH cores.
+				opt.setProgramDirty((addr < 0x400 ? 1 : 0) | (addr + 4 >= 0x400 ? 2 : 0));
 		}
 		else if (if_mode == 0x57 && (address & 3) == 3) {
 			addr_sel = address & ~3;

--- a/source/ronaldo/esp/esp_opt.hpp
+++ b/source/ronaldo/esp/esp_opt.hpp
@@ -188,29 +188,35 @@ public:
     data_core1.eramPtr = &esp->shared.eram.eram[0];
   }
 
-  void genProgram(ESP<lg2eram_size>* esp)
+  /* `cores` is a bit mask: 1 = core 0, 2 = core 1. A core's generated code
+   * depends only on its own program words (the ERAM decode reads core 1's),
+   * so a write burst that touched one core recompiles one core. The H8S
+   * loads a patch in ~60 bursts per ASIC, each one a full recompile at
+   * ~1 ms on the device, and that is the stall at patch change. */
+  void genProgram(ESP<lg2eram_size>* esp, uint32_t cores = 3)
   {
-    if (runCore0) m_rt.release(runCore0);
-    if (runCore1) m_rt.release(runCore1);
+    if ((cores & 1) && runCore0) m_rt.release(runCore0);
+    if ((cores & 2) && runCore1) m_rt.release(runCore1);
 
-    eramEmitter.init(esp);
-    coreEmitter0.init(esp, &esp->core0);
-    coreEmitter1.init(esp, &esp->core1);
+    if (cores & 2) eramEmitter.init(esp);
+    if (cores & 1) coreEmitter0.init(esp, &esp->core0);
+    if (cores & 2) coreEmitter1.init(esp, &esp->core1);
 
     updateCoef(esp);
 
     // logger.log("#### CORE 0 ####\n");
-    genCore(esp, 0, &coreEmitter0, &runCore0);
+    if (cores & 1) genCore(esp, 0, &coreEmitter0, &runCore0);
     
     // logger.log("\n\n\n#### CORE 1 ####\n");
-    genCore(esp, 1, &coreEmitter1, &runCore1, true);
+    if (cores & 2) genCore(esp, 1, &coreEmitter1, &runCore1, true);
 
     // fflush(logger._file);
     // printf("JITed ESP cores\n");
   }
   
-  void setProgramDirty()
+  void setProgramDirty(uint32_t cores = 3)
   {
+	  m_dirtyCores |= cores;
 	  m_programDirty = 3;
   }
 
@@ -219,7 +225,11 @@ public:
       if (m_programDirty > 0)
       {
           if (--m_programDirty == 0)
-              genProgram(m_esp);
+          {
+              const uint32_t cores = m_dirtyCores;
+              m_dirtyCores = 0;
+              genProgram(m_esp, cores);
+          }
 	  }
   }
 
@@ -261,6 +271,7 @@ private:
   asmjit::JitRuntime m_rt;
   asmjit::FileLogger logger;
   uint32_t m_programDirty = 0;
+  uint32_t m_dirtyCores = 0;
   
   typedef void(*RunCore)(int8_t* coefsPtr, int32_t *iramPtr, int32_t *gramPtr, CoreData *varPtr, uint32_t eramPos, uint32_t iramPos, int64_t unused1, int64_t unused2);
   RunCore runCore0 = nullptr, runCore1 = nullptr;


### PR DESCRIPTION
A patch load is roughly 60 program write bursts per ASIC, and every one of them
recompiled **both** ESP cores. A core's generated code depends only on its own
program words — core 0 owns intmem words `0..0x3ff`, core 1 the rest, and the
ERAM decode reads core 1's — so `setProgramDirty` now carries a core mask and
`genProgram` compiles only the cores that were actually written.

Both write paths supply the mask. The `0x54` path writes a single word, so it
names one core. The `0x56` path writes `pmem[addr] .. pmem[addr + 4]`, so a burst
that starts below the `0x400` boundary and ends at or above it names both.

The mask accumulates across the three-sample dirty delay and is cleared when the
recompile runs, so several bursts landing in the same window still recompile each
affected core once. `setProgramDirty()` with no argument keeps its old meaning of
"both".

### Measured

The right harness here is a patch sweep, not sustained playback. Eight factory
patch changes across a 10 s render, on an idle Raspberry Pi 4B @ 1.8 GHz
(load 0.08, 46.7 → 52.5 °C), counterbalanced off/on/off/on:

| | core compiles | total compile time | per compile |
|---|---------------|--------------------|-------------|
| without | 1542 | 167.6 / 169.1 ms | 0.109 / 0.110 ms |
| with    |  775 |  83.4 /  83.3 ms | 0.108 ms |

**767 of 1542 core compiles avoided (49.7%)**, and 85 ms of the 168 ms.

Two things worth reading off that table:

- **The per-compile cost is unchanged** (0.108 ms either way). This change removes
  compiles; it does not make them cheaper. So it is independent of anything that
  speeds up code generation itself.
- **The recompile events are identical** — 762 `genProgram` calls in both builds.
  Only the amount of work per event changes, never when it happens.

The mask distribution is the design premise, measured rather than argued: of 762
bursts, **470 touched core 0 alone, 288 touched core 1 alone, and 4 straddled the
boundary** and legitimately needed both.

### What this is and isn't

It is a **stall** fix, not a throughput win. 167.6 ms of compile inside a 10 s
render is 1.7% of wall clock, and it is concentrated at the patch changes rather
than spread across playback. Halving it halves the pause when a player changes
patch. Sustained playback is not measurably faster, and I would rather say that
than have a throughput benchmark say it for me.

### Bit-exact

The sweep renders identically with and without the change — same length, same
SHA-256 — on both an A72 and an Apple M1.

### Disclosure on method

The measurement was made by toggling `m_dirtyCores |= cores` to
`m_dirtyCores = 3` on my own tree, a one-line revert to the previous behaviour so
that nothing but the mask differs. My patch-sweep harness depends on save-state
support that this branch does not carry, so the branch itself was not the binary
benchmarked — the change is identical, but the measurement is one step removed
and I would rather state that plainly.
