### PR TITLE
h8s: page bitmap + wide accesses straight to memory[] (+1.4%, bit-exact)

### DIFF
--- a/source/cpu/h8s/h8s.hpp
+++ b/source/cpu/h8s/h8s.hpp
@@ -50,6 +50,11 @@ public:
 	uint8 ccr {128};
 	uint8 exr {0};
 	H8SDevice* maps[1<<24] {};
+	/* One bit per 256-byte page of address space: set when ANY byte of the page
+	 * is memmap'd. Consulted before maps[] so the common case -- plain ROM/RAM,
+	 * which is every instruction fetch -- never touches the 128 MB table. */
+	uint64_t mappedPages[(1<<16) / 64] {};
+	bool pageMapped(int a) const { return (mappedPages[(a >> 8) >> 6] >> ((a >> 8) & 63)) & 1; }
 	unsigned long long  cycles {0};
 	unsigned long long pending_irqs {0};
 	
@@ -96,7 +101,7 @@ public:
 	void memmap(H8SDevice *dev,int start,int len = 1)
 	{
 		dev->setState(this);
-		for (int i=0;i<len;i++) maps[start+i]=dev;
+		for (int i=0;i<len;i++) { maps[start+i]=dev; mappedPages[((start+i) >> 8) >> 6] |= 1ULL << (((start+i) >> 8) & 63); }
 	}
 	
 	void loadmem(const uint8* data,uint32_t size,uint32_t address)
@@ -135,13 +140,13 @@ public:
 	void write8(int8 byte,int to) {
 		to&=0xffffff;
 		clockMem(to, lastwrite);
-		if (maps[to]) maps[to]->write(to, byte);
+		if (pageMapped(to) && maps[to]) maps[to]->write(to, byte);
 		else memory[to]=byte;
 	}
 	int8 read8(int from) {
 		from&=0xffffff;
 		clockMem(from, lastread);
-		if (maps[from]) return maps[from]->read(from);
+		if (pageMapped(from) && maps[from]) return maps[from]->read(from);
 		return memory[from];
 	}
 	

--- a/source/cpu/h8s/h8s.hpp
+++ b/source/cpu/h8s/h8s.hpp
@@ -132,10 +132,44 @@ public:
 	int16 read16(uint8 *from) {return read16((int)(from-memory));}
 	int8 read8(uint8 *from) {return read8((int)(from-memory));}
 	
-	void write32(int32 val,int to) {write16(val>>16,to);write16(val&0xffff,to+2);}
-	uint32 read32(int from) {uint32 s=read16(from)&0xffff;s=(s<<16)|(read16(from+2)&0xffff);return s;}
-	void write16(int16 val,int to) {write8(val>>8,to);write8(val&255,to+1);}
-	uint16 read16(int from) {uint16 s=read8(from)&255;s=(s<<8)|(read8(from+1)&255);return s;}
+	/* Wide accesses: when every byte lies in one unmapped 256-byte page the
+	 * bytes come straight from memory[] -- the per-byte clockMem() calls are kept
+	 * verbatim so the cycle count (and so the ASIC sample cadence) is unchanged. */
+	bool plainRun(int a, int n) const { return (((a ^ (a + n - 1)) >> 8) == 0) && !pageMapped(a); }
+	void write32(int32 val,int to) {
+		const int a = to & 0xffffff;
+		if (plainRun(a, 4)) {
+			clockMem(a, lastwrite); clockMem(a + 1, lastwrite); clockMem(a + 2, lastwrite); clockMem(a + 3, lastwrite);
+			memory[a] = (uint8)(val >> 24); memory[a + 1] = (uint8)(val >> 16); memory[a + 2] = (uint8)(val >> 8); memory[a + 3] = (uint8)val;
+			return;
+		}
+		write16(val>>16,to);write16(val&0xffff,to+2);
+	}
+	uint32 read32(int from) {
+		const int a = from & 0xffffff;
+		if (plainRun(a, 4)) {
+			clockMem(a, lastread); clockMem(a + 1, lastread); clockMem(a + 2, lastread); clockMem(a + 3, lastread);
+			return ((uint32)memory[a] << 24) | ((uint32)memory[a + 1] << 16) | ((uint32)memory[a + 2] << 8) | memory[a + 3];
+		}
+		uint32 s=read16(from)&0xffff;s=(s<<16)|(read16(from+2)&0xffff);return s;
+	}
+	void write16(int16 val,int to) {
+		const int a = to & 0xffffff;
+		if (plainRun(a, 2)) {
+			clockMem(a, lastwrite); clockMem(a + 1, lastwrite);
+			memory[a] = (uint8)(val >> 8); memory[a + 1] = (uint8)val;
+			return;
+		}
+		write8(val>>8,to);write8(val&255,to+1);
+	}
+	uint16 read16(int from) {
+		const int a = from & 0xffffff;
+		if (plainRun(a, 2)) {
+			clockMem(a, lastread); clockMem(a + 1, lastread);
+			return ((uint16)memory[a] << 8) | memory[a + 1];
+		}
+		uint16 s=read8(from)&255;s=(s<<8)|(read8(from+1)&255);return s;
+	}
 	
 	void write8(int8 byte,int to) {
 		to&=0xffffff;


### PR DESCRIPTION
Two commits, kept together because the first is not independently useful — it
exists to make the second correct.

**1. A page bitmap in front of `maps[]`.** `maps[]` is a 16 M-entry pointer
table, 128 MB, and every byte access probed it — including every instruction
fetch, which is almost never mapped. One bit per 256-byte page is 8 KB, so it
stays in cache and answers first; `maps[]` is touched only for pages that
actually hold a device. `memmap()` sets the bit for every page it covers, so the
bitmap is a superset of `maps[]` by construction and the extra test cannot change
behaviour.

**2. Wide accesses that lie in one unmapped page go straight to `memory[]`.** A
16- or 32-bit access was decomposed into 2 or 4 single-byte accesses, each
re-masking the address and re-testing the page. When the whole run is inside one
unmapped 256-byte page — the common case — the bytes move directly.

**The per-byte `clockMem()` calls are kept verbatim**, so the cycle count, and
therefore the ASIC sample cadence, is unchanged. That is what makes this
bit-exact rather than merely close.

### Why they are one PR

`plainRun()` needs a per-*page* answer to know that no byte of the run is mapped.
A per-address `maps[]` test would only cover the first byte, so a run whose
second or fourth byte lands on a device would silently bypass it. The bitmap is
what makes the fast path safe.

And measured separately, the bitmap alone does nothing worth reporting — see
below. Opening it as its own PR would mean asking you to review a change whose
honest measurement is "no effect".

### Measured

Upstream's own `jeTestConsole`, idle Raspberry Pi 4B @ 1.8 GHz (load 0.09–0.19,
47.7 → 55.5 °C per run). Six runs in a palindrome U,B,W,W,B,U so drift cannot
masquerade as a result. Byte totals at equal wall clock:

| build | mean wav bytes | same-build spread |
|-------|----------------|-------------------|
| upstream | 67,981,868 | 0.42% |
| + bitmap | 67,990,316 | 0.36% |
| + bitmap + wide | 68,921,900 | 0.11% |

- **bitmap alone: +0.01%** — indistinguishable from zero. Sorted, the runs
  interleave completely (`u1, b2x, b1x, u2`), well inside the noise band.
- **both together: +1.38%.** Both wide-access runs are the top two and clearly
  separated from the rest.

I would rather report the +0.01% than quietly fold it into the +1.38%.

### Bit-exact

```
upstream vs bitmap      : IDENTICAL over 67,840,512 bytes
upstream vs bitmap+wide : IDENTICAL over 67,840,512 bytes
upstream vs upstream    : IDENTICAL   (self-check)
wide     vs wide        : IDENTICAL   (self-check)
```

The self-checks matter: without them a matching pair only shows the harness is
deterministic, not that the change preserved behaviour.

**Extended check.** The window above is 128 s, which I no longer consider long
enough to be reassuring — a sibling change of mine passed a 129 s check and then
diverged at 176 s. So I re-ran this one against a vanilla `main` build long
enough to go well past that: **byte-identical over 200,435,712 bytes = 378.8 s**,
with two vanilla runs byte-identical to each other over the same window. The
demo's patch changes at 176 s and 223.8 s are both inside it.

### Scope

Architecture-neutral C++ — no emitter or intrinsics involved — so unlike the
ARM64 emitter work this needs no per-architecture port. Measured on A72 only;
I have no x86 hardware, so I make no claim for the size of the effect there.

