### PR TITLE
je8086: opt-in parallel ASIC pipeline (2.14x on a Pi 4B, bit-exact on a fixed 2-sample delay)

### DIFF
--- a/source/framework/juce/jucePluginData/tus_settings_dspaudio.rml
+++ b/source/framework/juce/jucePluginData/tus_settings_dspaudio.rml
@@ -97,6 +97,20 @@
 				</tr>
 			</table>
 		</div>
+		<div id="containerDspThreads" class="settings-advanced">
+			<h1>Multicore DSP (threads)</h1>
+			<settingsspacer1/>
+			<table id="dspThreadsTable" class="settings-table">
+				<tr class="settings-tr" id="dspThreadsEntry" style="display: none;">
+					<td class="settings-td">
+						<div id="dspThreadsButton" class="settings-checkboxwithlabel">
+							<button id="button" class="settings-checkbox"/>
+							<label id="label">Off (default)</label>
+						</div>
+					</td>
+				</tr>
+			</table>
+		</div>
 		<div id="containerDeviceSpecific"/>
 	</div>
 </body>

--- a/source/framework/juce/jucePluginEditorLib/pluginProcessor.cpp
+++ b/source/framework/juce/jucePluginEditorLib/pluginProcessor.cpp
@@ -93,6 +93,17 @@ namespace jucePluginEditorLib
 		return true;
 	}
 
+	bool Processor::setDspThreads(const uint32_t _threads)
+	{
+		if(!pluginLib::Processor::setDspThreads(_threads))
+			return false;
+
+		getConfig().setValue("dspThreads", static_cast<int>(_threads));
+		getConfig().saveIfNeeded();
+
+		return true;
+	}
+
 	bool Processor::hasEditor() const
 	{
 		return true; // (change this to false if you choose to not supply an editor)

--- a/source/framework/juce/jucePluginEditorLib/pluginProcessor.h
+++ b/source/framework/juce/jucePluginEditorLib/pluginProcessor.h
@@ -19,6 +19,7 @@ namespace jucePluginEditorLib
 		juce::PropertiesFile& getConfig() { return m_config; }
 
 		bool setLatencyBlocks(uint32_t _blocks) override;
+		bool setDspThreads(uint32_t _threads) override;
 
 		bool hasEditor() const override;
 		juce::AudioProcessorEditor* createEditor() override;

--- a/source/framework/juce/jucePluginEditorLib/settingsDspAudio.cpp
+++ b/source/framework/juce/jucePluginEditorLib/settingsDspAudio.cpp
@@ -142,6 +142,71 @@ namespace jucePluginEditorLib
 			}
 		}
 
+		// Multicore DSP buttons. Only offered by devices that can spread their DSP
+		// over several threads; everything else keeps the container hidden.
+		{
+			const auto maxThreads = m_processor.getMaxDspThreads();
+
+			if (maxThreads > 1)
+			{
+				if (auto* threadsTemplate = juceRmlUi::helper::findChild(_root, "dspThreadsEntry", false))
+				{
+					const auto current = m_processor.getDspThreads();
+					auto* parent = threadsTemplate->GetParentNode();
+
+					for (uint32_t threads = 0; threads <= maxThreads; ++threads)
+					{
+						if (threads == 1)	// one thread is the same thing as Off
+							continue;
+
+						auto clone = threadsTemplate->Clone();
+						auto* clonePtr = clone.get();
+						clonePtr->SetId("");
+						clonePtr->RemoveProperty("display");
+
+						auto* buttonContainer = juceRmlUi::helper::findChild(clonePtr, "dspThreadsButton");
+						auto* button = juceRmlUi::helper::findChildT<juceRmlUi::ElemButton>(buttonContainer, "button");
+						auto* label = juceRmlUi::helper::findChild(buttonContainer, "label");
+
+						std::stringstream ss;
+						if (threads == 0)
+							ss << "Off (default)";
+						else
+							ss << threads;
+						label->SetInnerRML(ss.str());
+
+						button->setChecked(current == threads);
+						m_dspThreadButtons.emplace_back(threads, button);
+
+						juceRmlUi::EventListener::Add(buttonContainer, Rml::EventId::Click, [this, threads](Rml::Event& _event)
+						{
+							_event.StopPropagation();
+
+							if (!m_processor.setDspThreads(threads))
+								return;
+
+							updateDspThreadButtons();
+
+							/* Same warning the latency buttons show, and for the same
+							 * reason: the pipeline delivers audio on a fixed delay that
+							 * forms part of the latency we report to the host. */
+							genericUI::MessageBox::showOk(genericUI::MessageBox::Icon::Warning, "Warning",
+								"This takes effect the next time the plugin is loaded, and it changes the reported latency.\n"
+								"It is advised to save, close & reopen the project to prevent synchronization issues.");
+						});
+
+						parent->InsertBefore(std::move(clone), threadsTemplate);
+					}
+
+					threadsTemplate->GetParentNode()->RemoveChild(threadsTemplate);
+				}
+			}
+			else if (auto* container = juceRmlUi::helper::findChild(_root, "containerDspThreads", false))
+			{
+				juceRmlUi::helper::setVisible(container, false);
+			}
+		}
+
 		// Output Gain slider
 		auto* sliderGain = juceRmlUi::helper::findChild(_root, "sliderGain", false);
 		auto* labelGain = juceRmlUi::helper::findChild(_root, "labelGain", false);
@@ -237,6 +302,16 @@ namespace jucePluginEditorLib
 		for (const auto [percent, button] : m_clockButtons)
 		{
 			button->setChecked(currentPercent == percent);
+		}
+	}
+
+	void SettingsDspAudio::updateDspThreadButtons() const
+	{
+		const auto current = m_processor.getDspThreads();
+
+		for (const auto [threads, button] : m_dspThreadButtons)
+		{
+			button->setChecked(current == threads);
 		}
 	}
 

--- a/source/framework/juce/jucePluginEditorLib/settingsDspAudio.h
+++ b/source/framework/juce/jucePluginEditorLib/settingsDspAudio.h
@@ -27,10 +27,12 @@ namespace jucePluginEditorLib
 		uint32_t getCurrentLatency() const;
 		void updateButtons() const;
 		void updateClockButtons() const;
+		void updateDspThreadButtons() const;
 		void updateResamplerButtons() const;
 
 		std::vector<std::pair<uint32_t, juceRmlUi::ElemButton*>> m_latencyButtons;
 		std::vector<std::pair<int, juceRmlUi::ElemButton*>> m_clockButtons;
+		std::vector<std::pair<uint32_t, juceRmlUi::ElemButton*>> m_dspThreadButtons;
 		std::vector<std::pair<synthLib::Resampler::Mode, juceRmlUi::ElemButton*>> m_resamplerButtons;
 	};
 }

--- a/source/framework/juce/jucePluginLib/processor.cpp
+++ b/source/framework/juce/jucePluginLib/processor.cpp
@@ -461,6 +461,21 @@ namespace pluginLib
 		return m_device->canModifyDspClock();
 	}
 
+	uint32_t Processor::getMaxDspThreads() const
+	{
+		if(!m_device)
+			return 1;
+		return m_device->getMaxDspThreads();
+	}
+
+	bool Processor::setDspThreads(const uint32_t _threads)
+	{
+		if(_threads > getMaxDspThreads())
+			return false;
+		m_dspThreads = _threads;
+		return true;
+	}
+
 	bool Processor::setPreferredDeviceSamplerate(const float _samplerate)
 	{
 		m_preferredDeviceSamplerate = _samplerate;

--- a/source/framework/juce/jucePluginLib/processor.h
+++ b/source/framework/juce/jucePluginLib/processor.h
@@ -131,6 +131,13 @@ namespace pluginLib
 		uint64_t getDspClockHz() const;
 		bool canModifyDspClock() const;
 
+		/* How many threads the device may spread its DSP over. 1 (the default)
+		 * means it cannot, and the setting is hidden. Applied when the device is
+		 * created, because it fixes the reported latency. */
+		uint32_t getMaxDspThreads() const;
+		uint32_t getDspThreads() const { return m_dspThreads; }
+		virtual bool setDspThreads(uint32_t _threads);
+
 		bool setPreferredDeviceSamplerate(float _samplerate);
 		float getPreferredDeviceSamplerate() const;
 		std::vector<float> getDeviceSupportedSamplerates() const;
@@ -260,6 +267,7 @@ namespace pluginLib
 		float m_outputGain = 1.0f;
 		float m_inputGain = 1.0f;
 		uint32_t m_dspClockPercent = 100;
+		uint32_t m_dspThreads = 0;
 		float m_preferredDeviceSamplerate = 0.0f;
 		synthLib::Resampler::Mode m_resamplerMode = synthLib::Resampler::Mode::Legacy;
 		float m_hostSamplerate = 0.0f;

--- a/source/framework/synthLib/device.h
+++ b/source/framework/synthLib/device.h
@@ -25,6 +25,9 @@ namespace synthLib
 		baseLib::MD5 romHash;
 		uint32_t customData = 0;
 		std::string homePath;
+		// 0 or 1 = render on one thread. Higher asks a device that supports it to
+		// spread its DSP over that many threads; see Device::getMaxDspThreads().
+		uint32_t dspThreads = 0;
 	};
 
 	class Device
@@ -82,6 +85,12 @@ namespace synthLib
 		virtual uint32_t getDspClockPercent() const = 0;
 		virtual uint64_t getDspClockHz() const = 0;
 		virtual bool canModifyDspClock() const { return false; }
+
+		/* How many threads this device can spread its DSP over. 1 means it renders
+		 * on the calling thread only, which is the default and true of every device
+		 * that has not opted in. The count is chosen at construction
+		 * (DeviceCreateParams::dspThreads) because it fixes the reported latency. */
+		virtual uint32_t getMaxDspThreads() const { return 1; }
 
 		BASELIB_NOINLINE virtual void release(std::vector<SMidiEvent>& _events);
 

--- a/source/ronaldo/esp/esp.hpp
+++ b/source/ronaldo/esp/esp.hpp
@@ -388,6 +388,11 @@ public:
 	void sync_cores() {core0.sync(); core1.sync(); if (lg2eram_size) shared.eram.tickSample();}
 
 	uint8_t readuC(uint32_t address) { return shared.readback_regs[address & 3]; }
+	/* The readback registers as a block. A pipeline stage that does not own this
+	 * ASIC still has to see its readback state, so the owning stage publishes it
+	 * and the others copy it in; see jePipeline.h. */
+	void getReadbackRegs(uint8_t *out) const { memcpy(out, shared.readback_regs, 4); }
+	void setReadbackRegs(const uint8_t *in) { memcpy(shared.readback_regs, in, 4); }
 
 	void writeuC(uint32_t address, uint8_t value) {
 		address&=0x3fff;

--- a/source/ronaldo/je8086/jeJucePlugin/jePluginProcessor.cpp
+++ b/source/ronaldo/je8086/jeJucePlugin/jePluginProcessor.cpp
@@ -43,6 +43,10 @@ namespace jeJucePlugin
 		getController();
 		const auto latencyBlocks = getConfig().getIntValue("latencyBlocks", static_cast<int>(getPlugin().getLatencyBlocks()));
 		Processor::setLatencyBlocks(latencyBlocks);
+
+		/* Read before the device exists: the thread count is applied at creation
+		 * because it fixes the reported latency and cannot change while running. */
+		pluginLib::Processor::setDspThreads(static_cast<uint32_t>(getConfig().getIntValue("dspThreads", 0)));
 	}
 
 	AudioPluginAudioProcessor::~AudioPluginAudioProcessor()
@@ -69,6 +73,7 @@ namespace jeJucePlugin
 		params.romData = rom.getData();
 		params.romName = rom.getName();
 		params.homePath = getDataFolder();
+		params.dspThreads = getDspThreads();
 
 		auto* d = new jeLib::Device(params);
 		if(!d->isValid())

--- a/source/ronaldo/je8086/jeLib/CMakeLists.txt
+++ b/source/ronaldo/je8086/jeLib/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
 	je8086devices.cpp je8086devices.h
 	jeLcd.cpp jeLcd.h
 	jemiditypes.h
+	jePipeline.cpp jePipeline.h
 	jeThread.cpp jeThread.h
 	jetypes.h
 	patch.cpp patch.h

--- a/source/ronaldo/je8086/jeLib/device.cpp
+++ b/source/ronaldo/je8086/jeLib/device.cpp
@@ -1,7 +1,10 @@
 #include "device.h"
 
 #include "je8086.h"
+
+#include <cstdlib>
 #include "jeThread.h"
+#include "jePipeline.h"
 #include "synthLib/midiToSysex.h"
 
 namespace
@@ -16,6 +19,11 @@ namespace
 
 namespace jeLib
 {
+	/* The pipeline hands one sample over for every sample rendered, taken this
+	 * many samples late. It only has to cover what is in flight; two is enough,
+	 * and a constant delay is what makes the output bit-exact against serial. */
+	static constexpr int64_t g_pipelineDelaySamples = 2;
+
 	constexpr uint8_t g_paramPageMasterVolume = 6;
 	constexpr uint8_t g_paramIndexMasterVolume = 0;
 
@@ -28,6 +36,23 @@ namespace jeLib
 		{
 			m_je8086.reset();
 			m_je8086.reset(new Je8086(_params.romData, ramDataFilename));
+		}
+
+		/* Opt in to the parallel ASIC pipeline (see jePipeline.h). Off unless asked
+		 * for, and only worth asking for where one core cannot render the chain in
+		 * real time -- an SBC, not a desktop. Measured on a Pi 4 through a CLAP
+		 * host: 0.7x real time without it, which is unusable; 1.8x with it.
+		 *
+		 * The count arrives through DeviceCreateParams, which the plugin fills in
+		 * from its own settings. It has to be decided here, before the engine
+		 * thread exists, because the pipeline delivers audio on a fixed delay that
+		 * forms part of the latency we report. */
+		if (_params.dspThreads > 1)
+		{
+			std::vector<int> bounds;
+			for (uint32_t i = 1; i < _params.dspThreads && i < 4; ++i)
+				bounds.push_back(static_cast<int>(i));
+			m_je8086->requestParallelPipeline(bounds, g_pipelineDelaySamples);
 		}
 
 		m_thread.reset(new JeThread(*m_je8086));
@@ -141,9 +166,27 @@ namespace jeLib
 		return 88'000'000;
 	}
 
+	uint32_t Device::getMaxDspThreads() const
+	{
+		return 4;	// H8S+ASIC0 | ASIC1 | ASIC2 | ASIC3
+	}
+
 	uint32_t Device::getInternalLatencyMidiToOutput() const
 	{
-		return static_cast<uint32_t>(getSamplerate() * 4.5f / 1000.0f); // 4.5 ms
+		// 4.5 ms, plus the pipeline's fixed delivery delay when it is running.
+		return static_cast<uint32_t>(getSamplerate() * 4.5f / 1000.0f) + pipelineDelay();
+	}
+
+	uint32_t Device::getInternalLatencyInputToOutput() const
+	{
+		/* Only our own delay is reported here. Whatever the audio path costs
+		 * without the pipeline is unchanged and unmeasured, so it stays 0. */
+		return pipelineDelay();
+	}
+
+	uint32_t Device::pipelineDelay() const
+	{
+		return m_je8086 && m_je8086->hasParallelPipeline() ? static_cast<uint32_t>(g_pipelineDelaySamples) : 0;
 	}
 
 	void Device::readMidiOut(std::vector<synthLib::SMidiEvent>& _midiOut)
@@ -158,6 +201,13 @@ namespace jeLib
 
 	void Device::processAudio(const synthLib::TAudioInputs& _inputs, const synthLib::TAudioOutputs& _outputs, const size_t _samples)
 	{
+		/* We are on the host's audio thread here, and it is the only place we ever
+		 * see how the host schedules it. The pipeline's workers mirror it one step
+		 * below; without that the host's realtime thread blocks on SCHED_OTHER
+		 * workers, which is priority inversion and sounds exactly like the plugin
+		 * being too slow. No-op when there is no pipeline or no realtime host. */
+		pipelineAdoptHostSchedule();
+
 		m_thread->processSamples(static_cast<uint32_t>(_samples), getExtraLatencySamples(), m_midiIn, m_midiOut);
 		m_midiIn.clear();
 

--- a/source/ronaldo/je8086/jeLib/device.h
+++ b/source/ronaldo/je8086/jeLib/device.h
@@ -33,6 +33,8 @@ namespace jeLib
 		uint32_t getChannelCountOut() override;
 		bool setDspClockPercent(uint32_t _percent) override;
 		uint32_t getDspClockPercent() const override;
+		uint32_t getMaxDspThreads() const override;
+		uint32_t getInternalLatencyInputToOutput() const override;
 		uint64_t getDspClockHz() const override;
 
 		uint32_t getInternalLatencyMidiToOutput() const override;
@@ -48,6 +50,8 @@ namespace jeLib
 		}
 
 	protected:
+		uint32_t pipelineDelay() const;
+
 		void readMidiOut(std::vector<synthLib::SMidiEvent>& _midiOut) override;
 		void processAudio(const synthLib::TAudioInputs& _inputs, const synthLib::TAudioOutputs& _outputs, size_t _samples) override;
 		bool sendMidi(const synthLib::SMidiEvent& _ev, std::vector<synthLib::SMidiEvent>& _response) override;

--- a/source/ronaldo/je8086/jeLib/je8086.cpp
+++ b/source/ronaldo/je8086/jeLib/je8086.cpp
@@ -1,5 +1,7 @@
 #include "je8086.h"
 
+#include "jePipeline.h"
+
 #include "baseLib/filesystem.h"
 
 #include "synthLib/deviceException.h"
@@ -89,11 +91,30 @@ namespace jeLib
 			m_midiInEvents.clear();
 		}
 
+		/* First step on this thread: this is where the pipeline has to be built,
+		 * because the stage state it installs is thread_local. */
+		if (m_pipelineRequested && !m_pipeline)
+		{
+			m_pipelineRequested = false;
+			m_pipeline.reset(new JePipeline(*this, m_pipelineBounds));
+			if (!m_pipeline->valid())
+				m_pipeline.reset();	// bad split; stay serial
+		}
+
 		emu.step();
 		timers.tick();
 		midi.tick();
 
 		asics.runForCycles(emu.getCycles() * 1323 / 625); // Convert from uC cycles to DSP steps. (this is (clockrate / 2) / (uc clock = 16000000), simplified)
+
+		if (m_pipeline)
+		{
+			/* Audio is produced on the last stage's thread but must be appended
+			 * here: the sample buffer and the MIDI rate limiter behind it belong
+			 * to this thread. */
+			m_pipeline->refreshParentReadbacks();
+			m_pipeline->deliver([this](const int32_t _l, const int32_t _r) { onReceiveSample(_l, _r); }, m_pipelineWindow);
+		}
 	}
 
 	void Je8086::setButton(const devices::SwitchType _type, const bool _pressed)
@@ -114,6 +135,20 @@ namespace jeLib
 		m_midiOutParser.write(_byte);
 	}
 
+	Je8086::~Je8086() = default;
+
+	void Je8086::requestParallelPipeline(const std::vector<int>& _bounds, const int64_t _window)
+	{
+		m_pipelineBounds = _bounds;
+		m_pipelineWindow = _window < 1 ? 1 : _window;
+		m_pipelineRequested = !_bounds.empty();
+	}
+
+	bool Je8086::hasParallelPipeline() const
+	{
+		return m_pipeline != nullptr;
+	}
+
 	void Je8086::onReceiveSample(int32_t _left, int32_t _right)
 	{
 		m_midiInRateLimiter.processSample();
@@ -129,6 +164,7 @@ namespace jeLib
 	{
 		SysexRemoteControl::sendSysexLcdCgRam(m_midiOutEvents, lcd);
 	}
+
 
 	void Je8086::runfactoryreset(const std::string& _ramDataFilename)
 	{

--- a/source/ronaldo/je8086/jeLib/je8086.h
+++ b/source/ronaldo/je8086/jeLib/je8086.h
@@ -8,8 +8,12 @@
 #include "synthLib/midiBufferParser.h"
 #include "synthLib/midiRateLimiter.h"
 
+#include <memory>
+
 namespace jeLib
 {
+	class JePipeline;
+
 	class Je8086
 	{
 	public:
@@ -17,7 +21,7 @@ namespace jeLib
 		using SampleBuffer = std::vector<SampleFrame>;
 
 		Je8086(const std::vector<uint8_t>& _romData, const std::string& _ramDataFilename);
-		~Je8086() = default;
+		~Je8086();
 
 		void addMidiEvent(const synthLib::SMidiEvent& _event);
 		void readMidiOut(std::vector<synthLib::SMidiEvent>& _events);
@@ -27,9 +31,20 @@ namespace jeLib
 
 		void step();
 
+		/* Opt in to the parallel ASIC pipeline; see jePipeline.h. Off unless asked
+		 * for, and worth asking for only where one core cannot render the chain in
+		 * real time. The pipeline is created on the FIRST step() rather than here:
+		 * the stage-scoped emulator state it installs is thread_local, so it has to
+		 * land on whichever thread drives step(), not on the caller's. */
+		void requestParallelPipeline(const std::vector<int>& _bounds, int64_t _window = 2);
+		bool hasParallelPipeline() const;
+
 		bool hasDoneFactoryReset() const { return m_factoryreset; }
 
 		void setButton(devices::SwitchType _type, bool _pressed);
+
+		devices::MultiAsic& getAsics() { return asics; }
+
 
 	private:
 		static void onLedsChanged(devices::Port* _port);
@@ -53,6 +68,11 @@ namespace jeLib
 		int ctr {0};
 
 		bool m_factoryreset = false;
+
+		std::unique_ptr<JePipeline> m_pipeline;
+		std::vector<int> m_pipelineBounds;
+		bool m_pipelineRequested = false;
+		int64_t m_pipelineWindow = 64;
 
 		synthLib::MidiBufferParser m_midiOutParser;
 		std::vector<synthLib::SMidiEvent> m_midiInEvents;

--- a/source/ronaldo/je8086/jeLib/je8086devices.h
+++ b/source/ronaldo/je8086/jeLib/je8086devices.h
@@ -108,12 +108,175 @@ namespace jeLib
 			kFader_PitchEnvD
 		};
 
+		/* Stage-scoped state. thread_local, not plain global: with fork every stage
+		 * got a private copy of the whole emulator for free, but a THREADED
+		 * pipeline runs all stages in one address space and each needs its own
+		 * bounds and handoff callbacks. Fork is unaffected -- the child continues
+		 * on the thread that inherited these values.
+		 *
+		 * Fork-parallel mode (stage-local, no race).
+		 * 0 = all ASICs (default), 1 = parent: H8S + ASICs [0, split),
+		 * 2 = child: ASICs [split, 4). */
+		inline thread_local int g_je_parallel_mode = 0;
+		/* First ASIC owned by the child. 2 (ASIC0+1 | ASIC2+3) is the historical split;
+		 * 1 (ASIC0 | ASIC1+2+3) balances the halves — the H8S is the parent's real cost.
+		 * Must be set before the fork; only 1 and 2 are supported (the 2->3 handoff
+		 * carries 10 words, more than the ring payload). */
+		inline int g_je_split_asic = 2;
+		/* Pipeline stage owned by THIS process: ASICs [lo, hi). The parent is
+		 * [0, g_je_split_asic); a child stage may be any contiguous run above it,
+		 * so a 3-stage {0}/{1}/{2,3} pipeline is the 2-stage code with different
+		 * bounds. Process-local after fork. */
+		inline thread_local int g_je_stage_lo = 0;
+		inline thread_local int g_je_stage_hi = 4;
+		/* Words handed from ASIC n to ASIC n+1 at GRAM 0x80.. (dest 0..), per boundary.
+		 * The 2->3 boundary also carries 0xa0/0xa2 -> 0x20/0x22, packed as words 8, 9
+		 * of the handoff payload (JE_HANDOFF_MAX). */
+		inline constexpr int g_je_handoff_words[3] = {3, 6, 8};
+		inline constexpr int JE_HANDOFF_MAX = 10;
+		/* Mode 1: called per sample with ASIC(split-1)'s handoff values
+		 * (g_je_handoff_words[split-1] of them). */
+		/* Audio out for the stage that owns ASIC3. postSample is a MultiAsic
+		 * MEMBER, so with fork each stage had its own; threads share one object
+		 * and the last stage's audio push would also be invoked by stage 0's
+		 * dummy call below. Stage-scoped hook instead: set it and the owning
+		 * stage uses it, leave it unset and postSample behaves as before. */
+		inline thread_local std::function<void(int32_t, int32_t)> g_je_stage_audio_out;
+		/* Mode 1 hands Device::process() a silent sample per rendered sample so it
+		 * keeps its expected count while the real audio is produced elsewhere --
+		 * correct when "elsewhere" is another PROCESS. When the stages are threads
+		 * the parent drains their audio into that same buffer itself, so the dummy
+		 * would interleave a zero with every real sample. Cleared by JePipeline. */
+		inline thread_local bool g_je_parent_dummy_audio = true;
+		inline thread_local std::function<void(const int32_t*)> g_je_gram_produce;
+		/* Mode 2: called per sample to receive those values.
+		 * Returns false if shutdown requested. */
+		inline thread_local std::function<bool(int32_t*)> g_je_gram_consume;
+		/* Mode 1: called when H8S writes to a child-owned ASIC's registers (PRAM
+		 * programming). Forwards the write to the child so it sees patch changes. */
+		inline thread_local std::function<void(int asic, uint32_t addr, uint8_t val)> g_je_uc_write_forward;
+
+		/* The parent's copy of the readback registers of ASICs it does NOT own.
+		 * With fork every stage had a private copy of the whole emulator, so the
+		 * H8S could read any ASIC directly. Threads share one set of objects, so a
+		 * direct read would race with the owning stage running that ASIC -- the
+		 * mirror image of the guard write() already has. The owning stage publishes
+		 * its four bytes and the parent reads them from here instead. */
+		inline thread_local uint8_t g_je_parent_readback[4][4] = {};
+
+
+
 		class MultiAsic : public H8SDevice
 		{
 		public:
 			void setPostSample(const std::function<void(int32_t, int32_t)>& _postSample) { postSample = _postSample; }
+			/* Real audio out: tap first, then the normal sink. */
+			void emitAudio(int32_t _l, int32_t _r) {
+				postSample(_l, _r);
+			}
 
-			void dump() {
+			/* Apply a forwarded uC write to a child-owned ASIC (child process) */
+			void applyUcWrite(int asic, uint32_t addr, uint8_t val) {
+				if (asic < g_je_stage_lo || asic >= g_je_stage_hi) return;
+				forAsic(asic, [&](auto& a) { a.writeuC(addr, val); });
+			}
+
+			/* Readback register forwarding for fork-parallel mode.
+			 * Child exports its ASICs' readback regs so the parent's H8S
+			 * sees current values instead of stale snapshot copies.
+			 * 4 bytes per ASIC. */
+			void getReadback(int asic, uint8_t *out) const {
+				forAsic(asic, [&](auto& a) { a.getReadbackRegs(out); });
+			}
+			void setReadback(int asic, const uint8_t *in) {
+				forAsic(asic, [&](auto& a) { a.setReadbackRegs(in); });
+			}
+			/* Parent-side: store a stage's published readbacks where read() will find
+			 * them, WITHOUT touching the ASIC object that stage is running. */
+			static void setParentReadback(int asic, const uint8_t *in) {
+				for (int i = 0; i < 4; i++) g_je_parent_readback[asic][i] = in[i];
+			}
+			void getAsic23Readback(uint8_t *a2, uint8_t *a3) const { getReadback(2, a2); getReadback(3, a3); }
+			void setAsic23Readback(const uint8_t *a2, const uint8_t *a3) { setReadback(2, a2); setReadback(3, a3); }
+
+			/* Boundary from -> from+1 (from = 0, 1, 2), same reads/writes as the serial path. */
+			void handoff(int from) {
+				const int n = g_je_handoff_words[from];
+				forAsic(from, [&](auto& src) {
+					forAsic(from + 1, [&](auto& dst) {
+						for (int k = 0; k < n; k++) dst.writeGRAM(src.readGRAM(0x80 + k * 2), k * 2);
+						if (from == 2) {
+							dst.writeGRAM(src.readGRAM(0xa0), 0x20);
+							dst.writeGRAM(src.readGRAM(0xa2), 0x22);
+						}
+					});
+				});
+			}
+			void readHandoff(int from, int32_t *gram) {
+				forAsic(from, [&](auto& src) {
+					for (int k = 0; k < g_je_handoff_words[from]; k++) gram[k] = src.readGRAM(0x80 + k * 2);
+					if (from == 2) { gram[8] = src.readGRAM(0xa0); gram[9] = src.readGRAM(0xa2); }
+				});
+			}
+			void writeHandoff(int to, const int32_t *gram) {
+				forAsic(to, [&](auto& dst) {
+					for (int k = 0; k < g_je_handoff_words[to - 1]; k++) dst.writeGRAM(gram[k], k * 2);
+					if (to == 3) { dst.writeGRAM(gram[8], 0x20); dst.writeGRAM(gram[9], 0x22); }
+				});
+			}
+			void runAsics(int first, int last) {
+				for (int i = first; i < last; i++) forAsic(i, [](auto& a) { a.opt.genProgramIfDirty(); });
+				for (int i = first; i < last; i++) forAsic(i, [](auto& a) { a.opt.callOptimized(&a); });
+			}
+			void syncAsics(int first, int last) {
+				for (int i = first; i < last; i++) forAsic(i, [](auto& a) { a.sync_cores(); });
+			}
+
+			/* Process a single ASIC2+3 sample driven by external GRAM data.
+			 * Called directly by fork child — no H8S needed.
+			 *
+			 * Ordering matches serial mode (mode 0):
+			 *   1. Run ASICs with GRAM from PREVIOUS handoff
+			 *   2. postSample (read audio output)
+			 *   3. Consume new GRAM from ring → write to ASIC2
+			 *   4. ASIC2→ASIC3 handoff
+			 *   5. sync_cores
+			 * This ensures ASIC2 always processes one-sample-old GRAM,
+			 * exactly like the serial path where handoff follows the run. */
+			bool processSampleAsic23() { return processSampleChild(); }
+			bool processSampleChild() {
+				const int lo = g_je_stage_lo, hi = g_je_stage_hi;
+				// 1. Run this stage's ASICs with existing GRAM (from previous iteration or snapshot)
+				runAsics(lo, hi);
+
+				// 2. Output: audio if this stage holds ASIC3, else the handoff to the
+				//    next stage — read PRE-sync, same point as the parent's produce.
+				if (hi == 4) {
+					const int32_t l = asic3.readGRAM(0xe8), r = asic3.readGRAM(0xec);
+					if (g_je_stage_audio_out) g_je_stage_audio_out(l, r);
+					else postSample(l, r);
+				} else if (g_je_gram_produce) {
+					int32_t gram[JE_HANDOFF_MAX];
+					readHandoff(hi - 1, gram);
+					g_je_gram_produce(gram);
+				}
+
+				// 3. Consume new GRAM from the previous stage (the lo-1 -> lo handoff)
+				if (g_je_gram_consume) {
+					int32_t gram[JE_HANDOFF_MAX];
+					if (!g_je_gram_consume(gram)) return false;
+					writeHandoff(lo, gram);
+				}
+
+				// 4. Remaining handoffs inside this stage (for next sample)
+				for (int b = lo; b < hi - 1; b++) handoff(b);
+
+				// 5. sync_cores
+				syncAsics(lo, hi);
+				return true;
+			}
+
+		void dump() {
 				asic0.dump("dumps/asic0.bin", "dumps/asic0.txt");
 				asic1.dump("dumps/asic1.bin", "dumps/asic1.txt");
 				asic2.dump("dumps/asic2.bin", "dumps/asic2.txt");
@@ -123,67 +286,116 @@ namespace jeLib
 			uint8_t read(uint32_t _address) override
 			{
 				const int asic = (_address >> 14) & 3; _address &= 0x3fff;
-				if (asic == 0) return asic0.readuC(_address);
-				if (asic == 1) return asic1.readuC(_address);
-				if (asic == 2) return asic2.readuC(_address);
-				return asic3.readuC(_address);
+				// Mirror of the guard in write(): the parent owns [0, split) only, and
+				// reading an ASIC another thread is running is a data race. Answer from
+				// the snapshot that stage published instead.
+				if (g_je_parallel_mode == 1 && asic >= g_je_split_asic)
+					return g_je_parent_readback[asic][_address & 3];
+				uint8_t v = 0;
+				forAsic(asic, [&](auto& a) { v = a.readuC(_address); });
+				return v;
 			}
 
 			void write(uint32_t _address, uint8_t _value) override
 			{
 				const int asic = (_address >> 14) & 3; _address &= 0x3fff;
-				if (asic == 0) asic0.writeuC(_address, _value);
-				else if (asic == 1) asic1.writeuC(_address, _value);
-				else if (asic == 2) asic2.writeuC(_address, _value);
-				else asic3.writeuC(_address, _value);
+				// In parallel mode the parent owns [0, split) only; a write to a
+				// child-owned ASIC is forwarded, not applied to the parent's stale copy.
+				if (g_je_parallel_mode == 1 && asic >= g_je_split_asic) {
+					if (g_je_uc_write_forward) g_je_uc_write_forward(asic, _address, _value);
+					return;
+				}
+				forAsic(asic, [&](auto& a) { a.writeuC(_address, _value); });
 			}
 			
 			void runForCycles(uint64_t cycles) {
 				uint64_t diff = cycles + cyclesResidual - lastCycles;
 				lastCycles = cycles;
 
+				/* Called once per H8S instruction; a sample boundary is crossed on
+				 * one call in ~40, so skip the div/mod (and the loop) otherwise. */
+				if (diff < (768/2)) { cyclesResidual = diff; return; }
 				uint64_t samples = diff / (768/2);
 				cyclesResidual = diff % (768/2);
 
 				for (int i = 0; i < samples; i++) {
-					// Intepreter version
-					// for (size_t j = 0; j < (768/2); j++) asic0.step_cores();
-					// for (size_t j = 0; j < (768/2); j++) asic1.step_cores();
-					// for (size_t j = 0; j < (768/2); j++) asic2.step_cores();
-					// for (size_t j = 0; j < (768/2); j++) asic3.step_cores();
+					const int mode = g_je_parallel_mode;
 
-					// JIT version
-					asic0.opt.genProgramIfDirty();
-					asic1.opt.genProgramIfDirty();
-					asic2.opt.genProgramIfDirty();
-					asic3.opt.genProgramIfDirty();
+					if (mode == 0) {
+						// Original serial path — preserved exactly.
+						// All 4 ASICs run with GRAM from previous sample,
+						// then GRAM handoff writes values for next sample.
+						asic0.opt.genProgramIfDirty();
+						asic1.opt.genProgramIfDirty();
+						asic2.opt.genProgramIfDirty();
+						asic3.opt.genProgramIfDirty();
 
-					asic0.opt.callOptimized(&asic0);
-					asic1.opt.callOptimized(&asic1);
-					asic2.opt.callOptimized(&asic2);
-					asic3.opt.callOptimized(&asic3);
+						asic0.opt.callOptimized(&asic0);
+						asic1.opt.callOptimized(&asic1);
+						asic2.opt.callOptimized(&asic2);
+						asic3.opt.callOptimized(&asic3);
 
-					// Last DSP audio output
-					postSample(asic3.readGRAM(0xe8), asic3.readGRAM(0xec));
-					
-					// DSP->DSP communication
-					for (int k = 0; k <= 0x4; k += 2) asic1.writeGRAM(asic0.readGRAM(0x80 + k), k);
-					for (int k = 0; k <= 0xa; k += 2) asic2.writeGRAM(asic1.readGRAM(0x80 + k), k);
-					for (int k = 0; k <= 0xe; k += 2) asic3.writeGRAM(asic2.readGRAM(0x80 + k), k);
-					asic3.writeGRAM(asic2.readGRAM(0xa0), 0x20);
-					asic3.writeGRAM(asic2.readGRAM(0xa2), 0x22);
+						emitAudio(asic3.readGRAM(0xe8), asic3.readGRAM(0xec));
 
-					// Advance PCs
-					asic0.sync_cores();
-					asic1.sync_cores();
-					asic2.sync_cores();
-					asic3.sync_cores();
+						for (int k = 0; k <= 0x4; k += 2) asic1.writeGRAM(asic0.readGRAM(0x80 + k), k);
+						for (int k = 0; k <= 0xa; k += 2) asic2.writeGRAM(asic1.readGRAM(0x80 + k), k);
+						for (int k = 0; k <= 0xe; k += 2) asic3.writeGRAM(asic2.readGRAM(0x80 + k), k);
+						asic3.writeGRAM(asic2.readGRAM(0xa0), 0x20);
+						asic3.writeGRAM(asic2.readGRAM(0xa2), 0x22);
+
+						asic0.sync_cores();
+						asic1.sync_cores();
+						asic2.sync_cores();
+						asic3.sync_cores();
+					} else if (mode == 1) {
+						// Parent process: ASICs [0, split).
+						// Must mirror mode 0's ordering: the handoff READ happens
+						// BEFORE sync_cores. GRAM is a rotating buffer indexed by
+						// (offset + iramPos), and sync_cores decrements iramPos,
+						// so a post-sync read returns the previous sample's
+						// neighbouring slot — silently producing data shifted by
+						// one GRAM address.
+						const int split = g_je_split_asic;
+						runAsics(0, split);
+						for (int b = 0; b < split - 1; b++) handoff(b);
+						// Read the last parent ASIC's outputs PRE-sync (same point as serial mode 0)
+						if (g_je_gram_produce) {
+							int32_t gram[JE_HANDOFF_MAX];
+							readHandoff(split - 1, gram);
+							g_je_gram_produce(gram);
+						}
+						syncAsics(0, split);
+						// Dummy postSample so Device::process() gets its
+						// expected audio output and doesn't spin forever
+						if (g_je_parent_dummy_audio)
+							postSample(0, 0);
+					} else {
+						// Child process driven through the H8S (unused by the fork
+						// paths, which call processSampleChild directly).
+						const int split = g_je_split_asic;
+						if (g_je_gram_consume) {
+							int32_t gram[JE_HANDOFF_MAX];
+							if (!g_je_gram_consume(gram)) break;
+							writeHandoff(split, gram);
+						}
+						runAsics(split, 4);
+						for (int b = split; b < 3; b++) handoff(b);
+						emitAudio(asic3.readGRAM(0xe8), asic3.readGRAM(0xec));
+						syncAsics(split, 4);
+					}
 				}
 			}
 		protected:
 			ESP<17> asic0;
 			ESP<0> asic1, asic2;
 			ESP<19> asic3; // should really be 18, but it works only with 19
+			// The four ASICs are three distinct template types, so dispatch by index.
+			template <class F> void forAsic(int i, F&& f) {
+				switch (i) { case 0: f(asic0); break; case 1: f(asic1); break; case 2: f(asic2); break; default: f(asic3); break; }
+			}
+			template <class F> void forAsic(int i, F&& f) const {
+				switch (i) { case 0: f(asic0); break; case 1: f(asic1); break; case 2: f(asic2); break; default: f(asic3); break; }
+			}
 			enum {stepsPerFS = 384};
 			std::function<void(int32_t, int32_t)> postSample;
 			uint64_t lastCycles = 0, cyclesResidual = 0;
@@ -250,6 +462,7 @@ namespace jeLib
 			static int getLedId(const uint32_t _index) {return lits[_index];}
 
 			bool getLed(const uint32_t _i) const { const int w = getLedId(_i); return (leds[w >> 3] & (1 << (w & 7))); }
+
 		protected:
 			static int lits[];
 			static const char* const litnames[66];
@@ -302,6 +515,7 @@ namespace jeLib
 				// e.g. cutoff = VR12, so n = 12 + 15 = 27. See datasheet.
 				values[which] = value;
 			}
+
 		protected:
 			int8 scanning {0}, p6dr {0}, adcsr {0};
 			int values[64] {};

--- a/source/ronaldo/je8086/jeLib/jePipeline.cpp
+++ b/source/ronaldo/je8086/jeLib/jePipeline.cpp
@@ -1,0 +1,502 @@
+#include "jePipeline.h"
+
+#include "je8086.h"
+#include "je8086devices.h"
+
+#include "baseLib/os.h"
+
+#include <atomic>
+#include <cstring>
+#include <cstdlib>
+#include <ctime>
+
+#ifdef __linux__
+#include <sched.h>
+#include <pthread.h>
+#endif
+
+namespace jeLib
+{
+	namespace
+	{
+		/* Raise this thread to SCHED_FIFO.
+		 *
+		 * A host calls process() from a realtime thread -- Ardour uses FIFO 78 --
+		 * and jeLib then hands the work to JeThread, which is SCHED_OTHER, and this
+		 * pipeline hands it on again to stage threads that were also SCHED_OTHER.
+		 * The host's realtime thread therefore BLOCKS ON NON-REALTIME WORKERS, and
+		 * whenever a GUI or an X server wants the CPU those workers are scheduled
+		 * late and the deadline is missed. Measured in Ardour on a Pi: continuous
+		 * underruns with 70% of the CPU idle, which is the signature of priority
+		 * inversion rather than of too little compute.
+		 *
+		 * Stay BELOW the host's own audio thread: we are a producer it waits on,
+		 * not a peer, and outranking it only moves the starvation elsewhere.
+		 * Silently does nothing without permission (see RLIMIT_RTPRIO). */
+		/* What the host's audio thread told us about itself, and a generation so
+		 * workers notice. The pipeline is built during boot, long before a host
+		 * ever calls process(), so the schedule cannot simply be read at
+		 * construction -- it arrives later and every worker adopts it then. */
+		struct HostSchedule
+		{
+			std::atomic<int> policy{-1};
+			std::atomic<int> priority{0};
+			std::atomic<uint32_t> generation{0};
+		};
+
+		inline HostSchedule& hostSchedule()
+		{
+			static HostSchedule s;
+			return s;
+		}
+
+		inline bool raiseRealtime()
+		{
+#ifdef __linux__
+			int policy = SCHED_FIFO;
+			int prio = 0;
+
+			{
+				policy = hostSchedule().policy.load(std::memory_order_relaxed);
+
+				// The host is not realtime, so neither are we. Taking priority
+				// uninvited is rude, and pointless if nobody is waiting on us.
+				if (policy != SCHED_FIFO && policy != SCHED_RR)
+					return false;
+
+				/* One step BELOW the host's audio thread: we are a producer it
+				 * waits on, not a peer, and outranking it only moves the
+				 * starvation elsewhere. */
+				prio = hostSchedule().priority.load(std::memory_order_relaxed) - 1;
+
+				const int lo = sched_get_priority_min(policy);
+				if (prio < lo)
+					prio = lo;
+			}
+
+			if (prio <= 0)
+				return false;
+
+			sched_param sp{};
+			sp.sched_priority = prio;
+			return pthread_setschedparam(pthread_self(), policy, &sp) == 0;
+#else
+			return false;
+#endif
+		}
+
+		/* Cheap enough to sit in the sample loop: one relaxed load unless the
+		 * host's schedule actually changed. */
+		inline void followHostSchedule(uint32_t& _seen)
+		{
+			const auto gen = hostSchedule().generation.load(std::memory_order_relaxed);
+			if (gen == _seen)
+				return;
+			_seen = gen;
+			raiseRealtime();
+		}
+
+		/* Spin briefly, then SLEEP. A pure spin is faster on an idle benchmark box
+		 * and ruinous on a machine that also has to play the audio: when a real
+		 * consumer paces us we are ahead of it most of the time, so the stages sit
+		 * in the wait burning whole cores and starving the process that owns the
+		 * sound card. Measured with aplay at a 20 ms buffer: spinning gave 12
+		 * underruns in 15 s at normal priority and 115 at SCHED_FIFO 60, because a
+		 * spinning realtime thread never yields to the consumer at all.
+		 *
+		 * The back-off is bounded well under one audio block so it cannot become
+		 * the thing that misses a deadline. */
+		inline void cpuRelax()
+		{
+#if defined(__aarch64__) || defined(__arm__)
+			__asm__ __volatile__("yield" ::: "memory");
+#elif defined(__x86_64__) || defined(__i386__)
+			__asm__ __volatile__("pause" ::: "memory");
+#endif
+		}
+
+		template<typename Pred, typename Stop>
+		inline bool spinWait(Pred _pred, Stop _stop)
+		{
+			/* Sleep length is a real-time trade, not a throughput one. A sample is
+			 * 11 us at 88.2 kHz, so a 200 us sleep costs ~18 samples of wake-up on
+			 * every handoff; chained across stages that is what eats a small audio
+			 * buffer, and it is why this could not go below a 26 ms buffer live
+			 * even with two thirds of the CPU idle. Stay sub-sample. */
+			constexpr uint32_t s_spins = 4096;
+			constexpr uint32_t s_sleepNs = 5'000;
+
+			uint32_t spins = 0;
+			while (!_pred())
+			{
+				if (_stop()) return false;
+				if (++spins < s_spins)
+				{
+					cpuRelax();
+				}
+				else if (s_sleepNs)
+				{
+					timespec ts{0, static_cast<long>(s_sleepNs)};
+					nanosleep(&ts, nullptr);
+				}
+			}
+			return true;
+		}
+	}
+
+	struct JePipeline::Impl
+	{
+		struct Handoff { int32_t gram[HandoffCount]; };
+		struct Audio { int32_t left, right; };
+		struct UcWrite { uint8_t asic, val; uint16_t addr; uint32_t sample; };
+
+		struct Stage
+		{
+			int lo = 0, hi = 0;
+			std::atomic<bool> ready{false};
+
+			Handoff gramRing[RingCapacity];
+			std::atomic<int> gramWrite{0}, gramRead{0};
+
+			UcWrite ucRing[UcRingCap];
+			std::atomic<int> ucWrite{0}, ucRead{0};
+
+			std::atomic<int64_t> samplesProduced{0};
+		};
+
+		Stage stage[MaxStages];
+		std::thread threads[MaxStages];
+		std::atomic<bool> shutdown{false};
+
+		Audio audioRing[RingCapacity];
+		std::atomic<int> audioWrite{0}, audioRead{0};
+
+		uint8_t readback[4][4] = {};
+
+		std::atomic<int64_t> drained{0};
+		int64_t delivered = 0;	// caller's thread only
+
+		static int avail(const std::atomic<int>& _w, const std::atomic<int>& _r)
+		{
+			int d = _w.load(std::memory_order_acquire) - _r.load(std::memory_order_relaxed);
+			if (d < 0) d += RingCapacity * 2;
+			return d;
+		}
+
+		/* Same discipline for the control-write ring. Indices run modulo 2 * cap so
+		 * that a full ring is distinguishable from an empty one; storing them modulo
+		 * the capacity itself makes the two states identical and lets a producer
+		 * overwrite entries the consumer has not read. Occupancy measured at 14 of
+		 * 8192 in practice, so this is a guard rather than a hot path. */
+		static int ucAvail(const std::atomic<int>& _w, const std::atomic<int>& _r)
+		{
+			int d = _w.load(std::memory_order_acquire) - _r.load(std::memory_order_relaxed);
+			if (d < 0) d += UcRingCap * 2;
+			return d;
+		}
+	};
+
+	JePipeline::JePipeline(Je8086& _je, const std::vector<int>& _bounds)
+		: m_impl(new Impl()), m_je(_je)
+	{
+		if (_bounds.empty() || _bounds.size() >= MaxStages)
+			return;
+		for (size_t i = 0; i < _bounds.size(); ++i)
+		{
+			if (_bounds[i] < 1 || _bounds[i] > 3) return;
+			if (i && _bounds[i] <= _bounds[i - 1]) return;
+		}
+
+		m_numStages = static_cast<int>(_bounds.size()) + 1;
+
+		auto& impl = *m_impl;
+		impl.stage[0].lo = 0;
+		impl.stage[0].hi = _bounds[0];
+		for (int s = 1; s < m_numStages; ++s)
+		{
+			impl.stage[s].lo = _bounds[s - 1];
+			impl.stage[s].hi = (s < static_cast<int>(_bounds.size())) ? _bounds[s] : 4;
+		}
+
+		installParentHooks(_bounds[0]);
+		/* This runs on whichever thread drives step() -- JeThread -- and that
+		 * thread renders stage 0, so it needs the same treatment as the stages. */
+		raiseRealtime();
+
+		for (int s = 1; s < m_numStages; ++s)
+			impl.threads[s] = std::thread([this, s] { stageMain(s); });
+
+		/* Stages only need their thread_local state in place before the first
+		 * handoff arrives, but waiting here keeps a failure at construction. */
+		for (int s = 1; s < m_numStages; ++s)
+			while (!impl.stage[s].ready.load(std::memory_order_acquire))
+				std::this_thread::yield();
+
+		m_valid = true;
+	}
+
+	JePipeline::~JePipeline()
+	{
+		auto& impl = *m_impl;
+		impl.shutdown.store(true, std::memory_order_release);
+		for (int s = 1; s < m_numStages; ++s)
+			if (impl.threads[s].joinable())
+				impl.threads[s].join();
+
+		// leave the emulator in serial mode
+		devices::g_je_parallel_mode = 0;
+		devices::g_je_stage_lo = 0;
+		devices::g_je_stage_hi = 4;
+		devices::g_je_gram_produce = nullptr;
+		devices::g_je_gram_consume = nullptr;
+		devices::g_je_uc_write_forward = nullptr;
+		devices::g_je_parent_dummy_audio = true;
+	}
+
+	/* Hooks for the caller's thread: it owns ASICs [0, firstBound), publishes
+	 * that boundary's handoff to stage 1, and forwards H8S register writes aimed
+	 * at ASICs it does not own. */
+	void JePipeline::installParentHooks(const int _firstBound)
+	{
+		auto& impl = *m_impl;
+
+		devices::g_je_split_asic = _firstBound;
+		devices::g_je_parallel_mode = 1;
+		devices::g_je_stage_lo = 0;
+		devices::g_je_stage_hi = _firstBound;
+		devices::g_je_parent_dummy_audio = false;	// we drain the stages' real audio ourselves
+
+		auto* next = &impl.stage[1];
+		devices::g_je_gram_produce = [this, next](const int32_t* _gram)
+		{
+			auto& impl2 = *m_impl;
+			if (!spinWait([&] { return Impl::avail(next->gramWrite, next->gramRead) < RingCapacity - 1; },
+			              [&] { return impl2.shutdown.load(std::memory_order_relaxed); }))
+				return;
+			const int wi = next->gramWrite.load(std::memory_order_relaxed) & RingMask;
+			std::memcpy(next->gramRing[wi].gram, _gram, sizeof(int32_t) * HandoffCount);
+			next->gramWrite.store((next->gramWrite.load(std::memory_order_relaxed) + 1) % (RingCapacity * 2),
+			                      std::memory_order_release);
+			impl2.stage[0].samplesProduced.fetch_add(1, std::memory_order_release);
+		};
+
+		/* The H8S programs ASICs the stages own; the write must land on the same
+		 * sample there as here, so it carries the parent's sample index. */
+		devices::g_je_uc_write_forward = [this](const int _asic, const uint32_t _addr, const uint8_t _val)
+		{
+			auto& impl2 = *m_impl;
+			for (int s = 1; s < m_numStages; ++s)
+			{
+				auto& st = impl2.stage[s];
+				if (_asic < st.lo || _asic >= st.hi)
+					continue;
+				if (!spinWait([&] { return Impl::ucAvail(st.ucWrite, st.ucRead) < UcRingCap - 1; },
+				              [&] { return impl2.shutdown.load(std::memory_order_relaxed); }))
+					return;
+				const int wi = st.ucWrite.load(std::memory_order_relaxed) % UcRingCap;
+				st.ucRing[wi] = { static_cast<uint8_t>(_asic), _val, static_cast<uint16_t>(_addr),
+				                  static_cast<uint32_t>(impl2.stage[0].samplesProduced.load(std::memory_order_relaxed)) };
+				st.ucWrite.store((st.ucWrite.load(std::memory_order_relaxed) + 1) % (UcRingCap * 2),
+				                 std::memory_order_release);
+				break;
+			}
+		};
+	}
+
+	void pipelineAdoptHostSchedule()
+	{
+#ifdef __linux__
+		int policy = 0;
+		sched_param sp{};
+		if (pthread_getschedparam(pthread_self(), &policy, &sp) != 0)
+			return;
+
+		auto& hs = hostSchedule();
+		if (hs.policy.load(std::memory_order_relaxed) == policy &&
+		    hs.priority.load(std::memory_order_relaxed) == sp.sched_priority)
+			return;
+
+		hs.policy.store(policy, std::memory_order_relaxed);
+		hs.priority.store(sp.sched_priority, std::memory_order_relaxed);
+		hs.generation.fetch_add(1, std::memory_order_release);
+#endif
+	}
+
+	void JePipeline::stageMain(const int _stage)
+	{
+		auto& impl = *m_impl;
+		auto& st = impl.stage[_stage];
+		auto& prev = impl.stage[_stage - 1];
+		const bool isLast = (_stage + 1) >= m_numStages;
+		const int lo = st.lo, hi = st.hi;
+
+		baseLib::setFlushDenormalsToZero();	// FPCR is per thread
+		raiseRealtime();
+
+		devices::g_je_parallel_mode = 2;
+		devices::g_je_stage_lo = lo;
+		devices::g_je_stage_hi = hi;
+
+		devices::g_je_gram_consume = [this, &st](int32_t* _gram) -> bool
+		{
+			auto& impl2 = *m_impl;
+			if (!spinWait([&] { return Impl::avail(st.gramWrite, st.gramRead) >= 1; },
+			              [&] { return impl2.shutdown.load(std::memory_order_relaxed); }))
+				return false;
+			const int ri = st.gramRead.load(std::memory_order_relaxed) & RingMask;
+			std::memcpy(_gram, st.gramRing[ri].gram, sizeof(int32_t) * HandoffCount);
+			st.gramRead.store((st.gramRead.load(std::memory_order_relaxed) + 1) % (RingCapacity * 2),
+			                  std::memory_order_release);
+			return true;
+		};
+
+		if (!isLast)
+		{
+			auto* next = &impl.stage[_stage + 1];
+			devices::g_je_gram_produce = [this, next, &st](const int32_t* _gram)
+			{
+				auto& impl2 = *m_impl;
+				if (!spinWait([&] { return Impl::avail(next->gramWrite, next->gramRead) < RingCapacity - 1; },
+				              [&] { return impl2.shutdown.load(std::memory_order_relaxed); }))
+					return;
+				const int wi = next->gramWrite.load(std::memory_order_relaxed) & RingMask;
+				std::memcpy(next->gramRing[wi].gram, _gram, sizeof(int32_t) * HandoffCount);
+				next->gramWrite.store((next->gramWrite.load(std::memory_order_relaxed) + 1) % (RingCapacity * 2),
+				                      std::memory_order_release);
+				st.samplesProduced.fetch_add(1, std::memory_order_release);
+			};
+		}
+		else
+		{
+			/* Stage-scoped, not MultiAsic::setPostSample: the object is shared, so
+			 * installing it there would also catch the caller's dummy postSample. */
+			devices::g_je_stage_audio_out = [this, &st](const int32_t _l, const int32_t _r)
+			{
+				auto& impl2 = *m_impl;
+				if (!spinWait([&] { return Impl::avail(impl2.audioWrite, impl2.audioRead) < RingCapacity - 1; },
+				              [&] { return impl2.shutdown.load(std::memory_order_relaxed); }))
+					return;
+				const int wi = impl2.audioWrite.load(std::memory_order_relaxed) & RingMask;
+				impl2.audioRing[wi] = { _l, _r };
+				impl2.audioWrite.store((impl2.audioWrite.load(std::memory_order_relaxed) + 1) % (RingCapacity * 2),
+				                       std::memory_order_release);
+				st.samplesProduced.fetch_add(1, std::memory_order_release);
+			};
+		}
+
+		st.ready.store(true, std::memory_order_release);
+
+		auto& asics = m_je.getAsics();
+		uint32_t sample = 0;
+		uint32_t seenSchedule = 0;
+
+		while (!impl.shutdown.load(std::memory_order_relaxed))
+		{
+			followHostSchedule(seenSchedule);
+			/* Wait for our input handoff AND for the previous stage to have
+			 * published this sample, so forwarded register writes stamped with it
+			 * have all arrived. */
+			if (!spinWait([&] { return Impl::avail(st.gramWrite, st.gramRead) >= 1 &&
+			                           prev.samplesProduced.load(std::memory_order_acquire) > static_cast<int64_t>(sample); },
+			              [&] { return impl.shutdown.load(std::memory_order_relaxed); }))
+				break;
+
+			while (Impl::ucAvail(st.ucWrite, st.ucRead) > 0)
+			{
+				const int ri = st.ucRead.load(std::memory_order_relaxed) % UcRingCap;
+				const auto w = st.ucRing[ri];
+				if (w.sample > sample)
+					break;
+				st.ucRead.store((st.ucRead.load(std::memory_order_relaxed) + 1) % (UcRingCap * 2),
+				                std::memory_order_release);
+				asics.applyUcWrite(w.asic, w.addr, w.val);
+			}
+
+			if (!asics.processSampleChild())
+				break;
+			++sample;
+
+			for (int a = lo; a < hi; ++a)
+				asics.getReadback(a, impl.readback[a]);
+
+		}
+	}
+
+	void JePipeline::drainAudio(const std::function<void(int32_t, int32_t)>& _sink, const bool _waitForOne)
+	{
+		auto& impl = *m_impl;
+		if (_waitForOne)
+		{
+			if (!spinWait([&] { return Impl::avail(impl.audioWrite, impl.audioRead) > 0; },
+			              [&] { return impl.shutdown.load(std::memory_order_relaxed); }))
+				return;
+		}
+		while (Impl::avail(impl.audioWrite, impl.audioRead) > 0)
+		{
+			const int ri = impl.audioRead.load(std::memory_order_relaxed) & RingMask;
+			_sink(impl.audioRing[ri].left, impl.audioRing[ri].right);
+			impl.drained.fetch_add(1, std::memory_order_relaxed);
+			impl.audioRead.store((impl.audioRead.load(std::memory_order_relaxed) + 1) % (RingCapacity * 2),
+			                     std::memory_order_release);
+		}
+	}
+
+	int64_t JePipeline::inFlight() const
+	{
+		auto& impl = *m_impl;
+		return impl.stage[0].samplesProduced.load(std::memory_order_acquire) -
+		       impl.drained.load(std::memory_order_relaxed);
+	}
+
+	void JePipeline::pump(const std::function<void(int32_t, int32_t)>& _sink, const int64_t _window)
+	{
+		auto& impl = *m_impl;
+		drainAudio(_sink);
+		while (inFlight() >= _window)
+		{
+			if (!spinWait([&] { return Impl::avail(impl.audioWrite, impl.audioRead) > 0; },
+			              [&] { return impl.shutdown.load(std::memory_order_relaxed); }))
+				return;
+			drainAudio(_sink);
+		}
+	}
+
+	void JePipeline::deliver(const std::function<void(int32_t, int32_t)>& _sink, const int64_t _latency)
+	{
+		/* This runs on the thread driving step(), which renders stage 0 and so
+		 * needs the same priority as the stages. */
+		static thread_local uint32_t seenSchedule = 0;
+		followHostSchedule(seenSchedule);
+
+		auto& impl = *m_impl;
+		const int64_t produced = impl.stage[0].samplesProduced.load(std::memory_order_acquire);
+
+		while (impl.delivered < produced)
+		{
+			if (impl.delivered < _latency)
+			{
+				_sink(0, 0);	// pipeline still filling
+			}
+			else
+			{
+				if (!spinWait([&] { return Impl::avail(impl.audioWrite, impl.audioRead) > 0; },
+				              [&] { return impl.shutdown.load(std::memory_order_relaxed); }))
+					return;
+				const int ri = impl.audioRead.load(std::memory_order_relaxed) & RingMask;
+				_sink(impl.audioRing[ri].left, impl.audioRing[ri].right);
+				impl.audioRead.store((impl.audioRead.load(std::memory_order_relaxed) + 1) % (RingCapacity * 2),
+				                     std::memory_order_release);
+				impl.drained.fetch_add(1, std::memory_order_relaxed);
+			}
+			++impl.delivered;
+		}
+	}
+
+	void JePipeline::refreshParentReadbacks()
+	{
+		auto& impl = *m_impl;
+		auto& asics = m_je.getAsics();
+		for (int a = devices::g_je_split_asic; a < 4; ++a)
+			devices::MultiAsic::setParentReadback(a, impl.readback[a]);
+	}
+}

--- a/source/ronaldo/je8086/jeLib/jePipeline.h
+++ b/source/ronaldo/je8086/jeLib/jePipeline.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace jeLib
+{
+	/* Tell the pipeline how the caller is scheduled, so its worker threads can
+	 * mirror it one priority below. Call from the HOST'S AUDIO THREAD -- that is
+	 * the thread whose deadline we must not miss. Safe to call every block; it
+	 * does nothing unless the schedule changed, and nothing at all if the caller
+	 * is not realtime. */
+	void pipelineAdoptHostSchedule();
+
+	class Je8086;
+
+	/* Opt-in parallel ASIC pipeline.
+	 *
+	 * The JP-8000 chain is four ASICs in series, so it does not parallelise by
+	 * splitting a sample across cores; it PIPELINES, one stage per core, each
+	 * handing its neighbour the GRAM words that cross the boundary. Throughput
+	 * is then bounded by the slowest stage rather than by their sum.
+	 *
+	 * This exists for CPUs that cannot render the chain in real time on one
+	 * core. Measured on a Raspberry Pi 4B at 1.8 GHz: 0.85x serial, 2.01x with
+	 * two stages, 3.02x with four. A desktop already clears real time serially
+	 * and gains nothing, which is why this is OFF unless a host asks for it.
+	 *
+	 * Threads, not processes: a plugin cannot fork. Stage-scoped emulator state
+	 * is thread_local (see je8086devices.h), and every stage steps a disjoint
+	 * set of Asic objects, so the stages share one Je8086 without locking.
+	 *
+	 * Ownership: stage 0 is the CALLER's thread (the one driving Je8086::step),
+	 * which runs the H8S plus ASICs [0, bounds[0]). This object owns the
+	 * threads for stages 1..n.
+	 */
+	class JePipeline
+	{
+	public:
+		static constexpr int MaxStages = 4;
+		static constexpr int RingCapacity = 1024;
+		static constexpr int RingMask = RingCapacity - 1;
+		static constexpr int HandoffCount = 10;	// widest boundary payload
+		static constexpr int UcRingCap = 8192;
+
+		/* `_bounds` lists the first ASIC of each stage after the parent, ascending
+		 * and within 1..3; {1,2,3} is the four-stage split. Check valid() before
+		 * use.
+		 *
+		 * Stages are deliberately NOT pinned to cores: measured worthless (three
+		 * stages pinned vs unpinned rendered 1.8x either way) and pinning is what
+		 * breaks a second instance, since the affinity would be chosen per stage
+		 * while the process is shared. */
+		JePipeline(Je8086& _je, const std::vector<int>& _bounds);
+		~JePipeline();
+
+		JePipeline(const JePipeline&) = delete;
+		JePipeline& operator=(const JePipeline&) = delete;
+
+		bool valid() const { return m_valid; }
+		int numStages() const { return m_numStages; }
+
+		/* Called on the caller's thread from Je8086::step(): moves whatever the
+		 * last stage has finished into the caller's sample buffer. Audio must not
+		 * be pushed there by a stage thread -- the buffer and the MIDI rate
+		 * limiter behind it are not thread safe. */
+		/* _waitForOne blocks until a sample is available. DO NOT use it from
+		 * step(): a step often advances the H8S without completing a sample at
+		 * all -- that is why JeThread loops `while (buffer empty) step()` -- so
+		 * waiting there deadlocks. Kept for callers that drive samples directly. */
+		void drainAudio(const std::function<void(int32_t, int32_t)>& _sink, bool _waitForOne = false);
+
+		/* Hand over finished audio and bound how far the H8S may run ahead of it.
+		 *
+		 * Without this the caller's `while (buffer empty) step()` advances the
+		 * H8S every time the stages have not finished yet, so the emulator covers
+		 * MORE emulated time than the host asked for -- measured at +17%. The
+		 * window is in samples: the parent may lead the audio by that much and no
+		 * further, which puts total emulated time back where serial has it.
+		 *
+		 * The window also trades exactness against overlap. At 1 the H8S is never
+		 * ahead, which is closest to serial and slowest; larger values let the
+		 * stages overlap but inject MIDI up to `window` samples off. */
+		void pump(const std::function<void(int32_t, int32_t)>& _sink, int64_t _window);
+
+		/* Hand the caller exactly one sample for every sample it has rendered,
+		 * taking audio that is a CONSTANT _latency samples old: silence until the
+		 * pipeline has filled, the real stream after that, waiting when a sample
+		 * has not arrived yet.
+		 *
+		 * That constant is what makes the mode exact and reproducible. A window
+		 * bounds how far the H8S may lead, but how far it ACTUALLY gets still
+		 * depends on thread timing, so the emulator covers a different span of
+		 * emulated time each run and MIDI lands in different places. Here the
+		 * count delivered is tied to the count rendered and nothing else, so the
+		 * H8S sees precisely the serial timeline while the stages stay _latency
+		 * samples behind and overlap freely. */
+		void deliver(const std::function<void(int32_t, int32_t)>& _sink, int64_t _latency);
+
+		int64_t inFlight() const;
+
+		/* Readbacks of ASICs this thread does not own, refreshed for the H8S. */
+		void refreshParentReadbacks();
+
+	private:
+		struct Impl;
+		std::unique_ptr<Impl> m_impl;
+
+		Je8086& m_je;
+		int m_numStages = 0;
+		bool m_valid = false;
+
+		void stageMain(int _stage);
+		void installParentHooks(int _firstBound);
+	};
+}


### PR DESCRIPTION
Opt-in parallel rendering of the JP-8000's ASIC chain. **Off by default; nothing
changes for any other device.** Opening as a draft because the design question is
genuinely yours — I'd rather be redirected before you spend review on it.

### The idea

The four ASICs are a chain: ASIC1 needs ASIC0's output *for the same sample*, and
so on. A sample therefore cannot be split across cores — which is the usual
objection, and it's correct. But a dependency chain is exactly what pipelining is
for. Stagger them in time instead:

```
stage 0 (H8S + ASIC0)  → sample S
stage 1 (ASIC1)        → sample S-1
stage 2 (ASIC2, ASIC3) → sample S-2
```

Every stage is busy, each on a different sample, and the chain's ordering is
preserved exactly. What crosses between stages is the GRAM handoff the chain
already has — 3, 6 or 8 words depending on the boundary.

### Determinism

Audio is delivered on a **fixed delay**, not when a stage happens to finish: one
sample handed over per sample rendered, taken a constant number of samples late,
so output is tied to counters rather than to thread timing. Bounding how far the
H8S may run ahead is *not* sufficient on its own — three runs at a bounded window
gave three different hashes.

Verified: the pipeline's output is the serial stream delayed by **exactly 2
samples**, byte-identical, at 2, 3 and 4 stages. Shifts of 1, 3 and 4 all fail
immediately, so this is an exact property rather than an approximate one.

One earlier qualification is now resolved: stacked with the engine PRs this
used to diverge at 176 s, which turned out to be #300 — the ARM64 JIT's entry
state, not anything in this branch or the emitter. On top of that fix the
byte-identical property holds for the full stack at 2, 3 and 4 stages,
verified over 380 s on a Pi 4 (gcc) and 200 s on an M1 (clang).

The delay does not grow with stage count — the parent blocks if a stage hasn't
reached the sample yet, so it's a delivery contract rather than pipeline depth.
2 samples at 88.2 kHz internal is ~23 us, and it is **reported, not hidden**:
`getInternalLatencyMidiToOutput()` adds it to the existing 4.5 ms and
`getInternalLatencyInputToOutput()` returns it, both zero unless the pipeline is
running.

### Measured

`jeTestConsole`, idle Raspberry Pi 4B @ 1.8 GHz, equal wall clock, palindrome
order (serial, 3, 2, 2, 3, serial) so drift can't masquerade as a result. The
pipeline is a runtime setting, so this is one binary throughout — no cross-build
baseline to get wrong.

| configuration | vs serial | real-time | run-to-run |
|---------------|-----------|-----------|------------|
| serial | 1.000x | 0.42x | 0.32% |
| 2 stages | 1.575x | 0.64x | 0.01% |
| **3 stages** | **2.143x** | **0.94x** | 0.24% |

So on this hardware it takes the JE-8086 from **0.42x real time, which is
unusable, to 0.94x — borderline**. I want to be precise about that: the pipeline
alone does not clear real time on a Pi with the current engine. It gets there
combined with engine work (#294), and I'd rather say so than let the two get
conflated.

### In combination with the other PRs

Since the standalone 0.94x above is borderline, here is what it does alongside
the three engine PRs (#293, #294, #296). All four merge cleanly onto `main`,
including the two that both touch `h8s.hpp`. Same Pi, same harness, palindromed,
vanilla upstream as the reference:

| build | vs vanilla | real-time |
|-------|-----------|-----------|
| vanilla upstream, serial | 1.000x | 0.43x |
| + #293 #294 #296, serial | 1.83x | 0.83x |
| + this PR, 2 stages | 3.82x | 1.75x |
| + this PR, 3 stages | ~4.5x | ~1.96–2.03x |

So the four together take a Pi 4B from **0.43x to about 2x real time**. The engine
PRs compose almost exactly as their individual claims predict (1.06 × 1.65 ×
1.014 = 1.77 predicted, 1.83 measured), which is a useful independent check that
none of them was double-counting.

Two things worth noting from that run:

- **Composite bit-exactness holds.** With all three engine PRs stacked, serial
  output is byte-identical to vanilla upstream over 68,297,472 bytes.
- **The 176 s divergence reported here earlier is resolved — it was #300**
  (the ARM64 JIT entered its generated programs with uninitialised registers,
  so its output depended on which thread called it; stage threads changed the
  caller). Nothing in this branch's handoff, forwarding or delivery was wrong
  — traces show GRAM handoffs, forwarded register writes and recompile ticks
  byte-identical between serial and pipeline. With #300 in the tree, the full
  stack renders byte-identical to serial at 2, 3 and 4 stages over 380 s on a
  Pi 4 and 200 s on an M1. Details in the comment below.

### Where it does NOT help — please read this before trying it

On an **Apple M1** (4 performance + 4 efficiency cores, busy desktop), same
binary:

| configuration | vs serial |
|---------------|-----------|
| serial | 1.000x |
| 2 stages | 1.873x |
| **4 stages** | **0.333x** |

Four stages is **three times slower than single-threaded**. A pipeline runs at
the pace of its slowest stage, so once stages land on efficiency cores the whole
chain drops to that pace. The same effect, milder, is why 4 stages loses to 3
inside a plugin host even on homogeneous cores: it pins every core and starves
the host's own audio thread.

This is why the count is a user setting rather than something derived from
`hardware_concurrency()`, and why I'd suggest 2-3 as the useful range.

### Honest disclosure

- **A pre-existing nondeterminism, not introduced here.** At the demo's first
  program change (223.8 s in), two runs of the same binary diverge. That happens
  with **stock upstream, single-threaded, no code of mine involved** — verified on
  a byte-identical vanilla build, six pairwise comparisons. It's timing-jitter
  dependent: an idle Pi is deterministic through it in serial (identical over
  378 s) and a busy M1 is not. The pipeline adds jitter, so it surfaces there
  too. I don't know what in the engine is timing-sensitive at a program change,
  and you'll know the firmware far better than I do — happy to open that
  separately if it's news to you.
- A host's per-plugin CPU readout **understates** this badly, because the work
  happens off the audio thread. REAPER showed 3.3% against roughly 1.4 cores.
- Measured on ARM64 only. No x86 hardware here, so no claim for it.

### Shape of the change

Three commits: two small ESP accessors, the pipeline itself, and a device
capability plus the settings control. The framework part follows
`canModifyDspClock()` exactly — the device declares `getMaxDspThreads()`, the
shared DSP & Audio panel shows the control only when the capability is there, and
six of the seven plugins in the tree see no behavioural change at all.

Stages are deliberately not pinned to cores: pinning measured worthless (three
stages, 1.8x either way) and it's what would break a second instance.

The obvious alternative — `clap.thread-pool` — would give this to CLAP hosts
only, and the project ships VST3 and AU as well, so it can't replace the plugin
owning its threads. It could be an additional path later.



