### PR TITLE
jucePluginEditorLib: Let `escape` close settings or return to host

### DIFF
--- a/source/framework/juce/jucePluginEditorLib/pluginEditor.cpp
+++ b/source/framework/juce/jucePluginEditorLib/pluginEditor.cpp
@@ -873,12 +873,13 @@ namespace jucePluginEditorLib
 					if (m_midiLearnModeActive)
 					{
 						setMidiLearnMode(false);
+						_event.StopPropagation();
 					}
-					else
+					else if (settingsOpened())
 					{
-						toggleSettings();
+						showSettings(false);
+						_event.StopPropagation();
 					}
-					_event.StopPropagation();
 					break;
 				default:;
 				}


### PR DESCRIPTION
In Live, `escape` closes plugin windows. The settings toggle prevents the default DAW behavior. Allow settings to be closed with `escape`, but do not open settings via `escape` key.