### PR TITLE
virusJucePlugin: Persist preferred device sample rate across instances

### DIFF
--- a/source/axel/virusJucePlugin/VirusProcessor.cpp
+++ b/source/axel/virusJucePlugin/VirusProcessor.cpp
@@ -11,6 +11,11 @@
 #include "synthLib/deviceException.h"
 #include "synthLib/lv2PresetExport.h"
 
+namespace
+{
+	constexpr auto g_preferredDeviceSamplerateKey = "preferredDeviceSamplerate";
+}
+
 namespace virus
 {
 	VirusProcessor::VirusProcessor(const BusesProperties& _busesProperties, const juce::PropertiesFile::Options& _configOptions, const pluginLib::Processor::Properties& _properties, const virusLib::DeviceModel _defaultModel)
@@ -23,6 +28,13 @@ namespace virus
 	{
 		destroyController();
 		destroyEditorState();
+	}
+
+	bool VirusProcessor::setPreferredDeviceSamplerate(const float _samplerate)
+	{
+		getConfig().setValue(g_preferredDeviceSamplerateKey, _samplerate);
+		getConfig().saveIfNeeded();
+		return Processor::setPreferredDeviceSamplerate(_samplerate);
 	}
 
 	//==============================================================================
@@ -74,6 +86,7 @@ namespace virus
 	void VirusProcessor::postConstruct(std::vector<virusLib::ROMFile>&& _roms)
 	{
 		m_roms = std::move(_roms);
+		Processor::setPreferredDeviceSamplerate(static_cast<float>(getConfig().getDoubleValue(g_preferredDeviceSamplerateKey, 0.0)));
 
 		evRomChanged.retain(getSelectedRom());
 

--- a/source/axel/virusJucePlugin/VirusProcessor.h
+++ b/source/axel/virusJucePlugin/VirusProcessor.h
@@ -15,7 +15,8 @@ namespace virus
 	    VirusProcessor(const BusesProperties& _busesProperties, const juce::PropertiesFile::Options& _configOptions, const pluginLib::Processor::Properties& _properties, virusLib::DeviceModel _defaultModel);
 	    ~VirusProcessor() override;
 
-	    void processBpm(float _bpm) override;
+		void processBpm(float _bpm) override;
+		bool setPreferredDeviceSamplerate(float _samplerate);
 
 		// _____________
 		//


### PR DESCRIPTION
Persist the preferred device sample rate globally so new plugin instances reuse the last selection, while defaulting to automatic sample-rate selection when no preference has been saved.